### PR TITLE
Replaces scope: 'openid profile'

### DIFF
--- a/example/src/AppBundle/Resources/views/Default/login.html.twig
+++ b/example/src/AppBundle/Resources/views/Default/login.html.twig
@@ -11,7 +11,7 @@
             callbackURL: 'http://localhost:8000/auth0/callback'
             , responseType: 'code'
             , authParams: {
-                scope: 'openid profile'
+                scope: 'openid name email'
             }
         });
     }


### PR DESCRIPTION
Replaces “scope: ‘openid profile’” with “scope: ‘openid name email’”.