### PR TITLE
Symfony 3.0 Changes

### DIFF
--- a/Tests/Security/JWTAuthenticatorTest.php
+++ b/Tests/Security/JWTAuthenticatorTest.php
@@ -10,8 +10,8 @@ class JWTAuthenticatorTest extends \PHPUnit_Framework_TestCase
     public function testTokenCreation()
     {
         $mockAuth0 = $this->getMockBuilder('Auth0\JWTAuthBundle\Security\Auth0Service')
-          ->disableOriginalConstructor()
-          ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $mockAuth0->expects($this->once())
             ->method('decodeJWT')
@@ -35,8 +35,34 @@ class JWTAuthenticatorTest extends \PHPUnit_Framework_TestCase
         $token = $authenticator->createToken($request, $providerKey);
 
         $this->assertEquals('anon.',$token->GetUser());
-        $this->assertEquals($providerKey,$token->getProviderKey());
-        $this->assertEquals($providerKey,$token->getProviderKey());
+        $this->assertEquals($providerKey, $token->getProviderKey());
+        $this->assertEquals($providerKey, $token->getProviderKey());
+    }
+
+    public function testNoAuthorization()
+    {
+        $mockAuth0 = $this->getMockBuilder('Auth0\JWTAuthBundle\Security\Auth0Service')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $authenticator = new JWTAuthenticator($mockAuth0);
+        $providerKey = 'providerKey';
+
+        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $request->headers = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+
+        $request->headers
+            ->expects($this->once())
+            ->method('get')
+            ->with('Authorization')
+            ->will($this->returnValue(NULL));
+
+        $token = $authenticator->createToken($request, $providerKey);
+
+        $this->assertInstanceOf('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken', $token);
+
+        $this->assertEquals($providerKey, $token->getProviderKey());
+        $this->assertNull($token->getCredentials());
     }
 
 }

--- a/Tests/Security/JWTAuthenticatorTest.php
+++ b/Tests/Security/JWTAuthenticatorTest.php
@@ -4,21 +4,29 @@ namespace Auth0\JWTAuthBundle\Tests\Security;
 
 use Auth0\JWTAuthBundle\Security\Auth0Service;
 use Auth0\JWTAuthBundle\Security\JWTAuthenticator;
-use Symfony\Component\HttpFoundation\Request;
 
 class JWTAuthenticatorTest extends \PHPUnit_Framework_TestCase
 {
     public function testTokenCreation()
     {
-        $authenticator = new JWTAuthenticator(new Auth0Service('client_id', null, null));
+        $mockAuth0 = $this->getMockBuilder('Auth0\JWTAuthBundle\Security\Auth0Service')
+          ->disableOriginalConstructor()
+          ->getMock();
+
+        $mockAuth0->expects($this->once())
+            ->method('decodeJWT')
+            ->will($this->returnValue(new \stdClass()));
+
+        $authenticator = new JWTAuthenticator($mockAuth0);
         $providerKey = 'providerKey';
 
         //generated with http://jwt.io/
         $JWT = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2RvbWFpbi5jb20vIiwic3ViIjoiYXV0aDB8MDAwMDAwMDAwMDAwMDAwMDAwMDAwMCIsImF1ZCI6ImNsaWVudF9pZCIsImV4cCI6MTQyMjQ0MDI3MSwiaWF0IjoxNDIyNDA0MjcxfQ.xSuCAetwfHpCWhE_5NqTrwHq0eQ7CVffQwgSqTHwwrY';
 
-        $request = $this->getMock('Request');
-        $request->headers = $this->getMock('ParameterBag');
-        $request->request
+        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $request->headers = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+
+        $request->headers
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('Authorization')
@@ -30,4 +38,5 @@ class JWTAuthenticatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($providerKey,$token->getProviderKey());
         $this->assertEquals($providerKey,$token->getProviderKey());
     }
+
 }

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+
+if (!@include __DIR__ . '/../vendor/autoload.php') {
+    die(<<<'EOT'
+You must set up the project dependencies, run the following commands:
+    curl -s http://getcomposer.org/installer | php
+    php composer.phar install
+
+EOT
+    );
+}
+
+$loader = require dirname(__DIR__).'/vendor/autoload.php';
+$loader->add('Auth0\\JWTAuthBundle\\', __DIR__);

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 
     "require": {
         "php": ">=5.3.3",
+        "symfony/symfony": "~3.0",
         "auth0/auth0-php": "~3.0"
     },
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="JWTAuthBundle Test Suite">
+            <directory>tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Security/JWTAuthenticator.php
+++ b/src/Security/JWTAuthenticator.php
@@ -6,19 +6,20 @@ namespace Auth0\JWTAuthBundle\Security;
 use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
-use Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface;
+use Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 
 use Auth0\JWTAuthBundle\Security\Core\JWTUserProviderInterface;
 
-class JWTAuthenticator extends ContainerAware implements SimplePreAuthenticatorInterface,AuthenticationFailureHandlerInterface
+class JWTAuthenticator implements SimplePreAuthenticatorInterface,AuthenticationFailureHandlerInterface
 {
+    use ContainerAwareTrait;
     protected $auth0Service;
 
     public function __construct(Auth0Service $auth0Service)


### PR DESCRIPTION
Updated `JWTAuthenticator` to use Trait rather than extending ContainerAware.

Updated tests and bundle configuration.