### PR TITLE
Fix deprecation warnings SF 3.1

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,7 +1,7 @@
 services:
     jwt_auth.auth0_service:
         class: "Auth0\\JWTAuthBundle\\Security\\Auth0Service"
-        arguments: [%jwt_auth.client_id%, %jwt_auth.client_secret%, %jwt_auth.domain%]
+        arguments: ["%jwt_auth.client_id%", "%jwt_auth.client_secret%", "%jwt_auth.domain%"]
 
     jwt_auth.jwt_authenticator:
         class:     "Auth0\\JWTAuthBundle\\Security\\JWTAuthenticator"


### PR DESCRIPTION
Fix to avoid errors such as:

```
Not quoting the scalar "%jwt_auth.client_id%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0: 1x
    1x in DefaultControllerTest::testIndex from Tests\AppBundle\Controller

Not quoting the scalar "%jwt_auth.client_secret%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0: 1x
    1x in DefaultControllerTest::testIndex from Tests\AppBundle\Controller

Not quoting the scalar "%jwt_auth.domain%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0: 1x
    1x in DefaultControllerTest::testIndex from Tests\AppBundle\Controller
```