### PR TITLE
Allow symfony/framework-bundle 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 
     "require": {
         "php": "^5.5 || ^7.0",
-        "symfony/framework-bundle": "^2.8 || ~3.0",
+        "symfony/framework-bundle": "^2.8 || ~3.0 || ~4.0",
         "auth0/auth0-php": "^5.0.3"
     },
 


### PR DESCRIPTION
This allows for installation under symfony/symfony 4.x.