### PR TITLE
Php7 strict fix

### DIFF
--- a/src/Security/Core/JWTUserProviderInterface.php
+++ b/src/Security/Core/JWTUserProviderInterface.php
@@ -3,6 +3,7 @@
 namespace Auth0\JWTAuthBundle\Security\Core;
 
 use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * @author german
@@ -15,13 +16,13 @@ interface JWTUserProviderInterface extends UserProviderInterface
      * This method must throw JWTInfoNotFoundException if the user is not
      * found.
      *
-     * @param string $jwt The decoded Json Web Token
+     * @param object $jwt The decoded Json Web Token
      *
      * @return UserInterface
      *
-     * @throws AuthenticationException if the user is not found
+     * @throws JWTInfoNotFoundException if the user is not found
      */
-    public function loadUserByJWT($jwt);
+    public function loadUserByJWT(object $jwt): UserInterface;
 
     /**
      * Returns an anonimous user
@@ -33,8 +34,8 @@ interface JWTUserProviderInterface extends UserProviderInterface
      *
      * @return UserInterface
      *
-     * @throws AuthenticationException
+     * @throws JWTInfoNotFoundException if no anonymous user can be used
      */
-    public function getAnonymousUser();
+    public function getAnonymousUser(): UserInterface;
 
 }

--- a/src/Security/Core/JWTUserProviderInterface.php
+++ b/src/Security/Core/JWTUserProviderInterface.php
@@ -25,12 +25,12 @@ interface JWTUserProviderInterface extends UserProviderInterface
     public function loadUserByJWT(object $jwt): UserInterface;
 
     /**
-     * Returns an anonimous user
+     * Returns an anonymous user
      *
      * This can return a JWTInfoNotFoundException exception if you don't want
-     * to handle anonimous users
+     * to handle anonymous users
      *
-     * Is recommended to return a user with the role IS_AUTHENTICATED_ANONYMOUSLY
+     * It is recommendeded to return a user with the role IS_AUTHENTICATED_ANONYMOUSLY
      *
      * @return UserInterface
      *


### PR DESCRIPTION
### Changes

Made `Auth0\JWTAuthBundle\Security\Core\JWTUserProviderInterface` comply with PHP7 strict settings, since the type-hinting was either missing or wrong.

### References

Following a test implementation of the Auth0 bundle in a PHP 7.2 / Symfony 4.2 stack (using your own examples), we found out that PHPStan was (accurately) complaining about missing/wrong type-hinting.

### Testing

Ran `vendor/bin/phpunit` with following output:

```
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

....                                                                4 / 4 (100%)

Time: 141 ms, Memory: 12.00MB

OK (4 tests, 12 assertions)
```

[x] This change has been tested on the latest version of Symfony

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
