### PR TITLE
serialize/unserialize methods are deprecated since Symfony 4.3

### DIFF
--- a/src/Security/Core/JWTInfoNotFoundException.php
+++ b/src/Security/Core/JWTInfoNotFoundException.php
@@ -42,22 +42,22 @@ class JWTInfoNotFoundException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function serialize()
+    public function __serialize(): array
     {
-        return serialize(array(
+        return serialize([
             $this->jwt,
-            parent::serialize(),
-        ));
+            parent::__serialize(),
+        ]);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function unserialize($str)
+    public function __unserialize(array $data): void
     {
-        list($this->jwt, $parentData) = unserialize($str);
+        [$this->jwt, $parentData] = unserialize($data);
 
-        parent::unserialize($parentData);
+        parent::__unserialize($parentData);
     }
 
     /**


### PR DESCRIPTION
### Changes

Fixed deprecation notices for `Auth0\JWTAuthBundle\Security\Core\JWTInfoNotFoundException` exception by extending `__serialize` and `__unserialize` instead of `serialize` and `unserialize`.

### References

Following an implementation on PHP 7.2 / Symfony 4.3, after writing tests for our implementation that are referencing the `JWTInfoNotFoundException` exception, and by using the PHPUnit Bridge from Symfony which checks for Symfony deprecations, it accurately outputted:

```
  1x: The "Symfony\Component\Security\Core\Exception\AuthenticationException::serialize()" method is considered final since Symfony 4.3, use __serialize() instead. It may change without further notice as of its next major version. You should not extend it from "Auth0\JWTAuthBundle\Security\Core\JWTInfoNotFoundException".
    1x in Auth0UserProviderTest::testLoadUserByJWT_noSubProperty from App\Tests\Security

  1x: The "Symfony\Component\Security\Core\Exception\AuthenticationException::serialize()" method is considered internal since Symfony 4.3, use __serialize() instead. It may change without further notice. You should not extend it from "Auth0\JWTAuthBundle\Security\Core\JWTInfoNotFoundException".
    1x in Auth0UserProviderTest::testLoadUserByJWT_noSubProperty from App\Tests\Security

  1x: The "Symfony\Component\Security\Core\Exception\AuthenticationException::unserialize()" method is considered final since Symfony 4.3, use __unserialize() instead. It may change without further notice as of its next major version. You should not extend it from "Auth0\JWTAuthBundle\Security\Core\JWTInfoNotFoundException".
    1x in Auth0UserProviderTest::testLoadUserByJWT_noSubProperty from App\Tests\Security

  1x: The "Symfony\Component\Security\Core\Exception\AuthenticationException::unserialize()" method is considered internal since Symfony 4.3, use __unserialize() instead. It may change without further notice. You should not extend it from "Auth0\JWTAuthBundle\Security\Core\JWTInfoNotFoundException".
    1x in Auth0UserProviderTest::testLoadUserByJWT_noSubProperty from App\Tests\Security

```

### Testing

PHPUnit output:
```
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

....                                                                4 / 4 (100%)

Time: 354 ms, Memory: 12.00MB

OK (4 tests, 12 assertions)

```

[x] This change has been tested on the latest version of Symfony

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
