### PR TITLE
GuardAuthenticator implementation for Symfony 2.8 and later

### DIFF
--- a/Tests/Security/Guard/JwtGuardAuthenticatorTest.php
+++ b/Tests/Security/Guard/JwtGuardAuthenticatorTest.php
@@ -245,7 +245,7 @@ class JwtGuardAuthenticatorTest extends TestCase
         $response = $this->guardAuthenticator->onAuthenticationFailure($request, $exception);
 
         $this->assertInstanceOf(JsonResponse::class, $response);
-        $this->assertSame(JsonResponse::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertSame(JsonResponse::HTTP_UNAUTHORIZED, $response->getStatusCode());
         $this->assertJsonStringEqualsJsonString(
             '{"message": "Authentication failed: Malformed token."}',
             $response->getContent()

--- a/Tests/Security/Guard/JwtGuardAuthenticatorTest.php
+++ b/Tests/Security/Guard/JwtGuardAuthenticatorTest.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace Auth0\JWTAuthBundle\Tests\Security\Guard;
+
+use Auth0\JWTAuthBundle\Security\Auth0Service;
+use Auth0\JWTAuthBundle\Security\Core\JWTUserProviderInterface;
+use Auth0\JWTAuthBundle\Security\Guard\JwtGuardAuthenticator;
+use Auth0\SDK\Exception\InvalidTokenException;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
+use stdClass;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+/**
+ * Tests the @see JwtGuardAuthenticator.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class JwtGuardAuthenticatorTest extends TestCase
+{
+    /**
+     * @var JwtGuardAuthenticator
+     */
+    private $guardAuthenticator;
+
+    /**
+     * @var PHPUnit_Framework_MockObject_MockObject
+     */
+    private $authZeroServiceMock;
+
+    /**
+     * Creates a JwtGuardAuthenticator instance for testing.
+     */
+    protected function setUp()
+    {
+        $this->authZeroServiceMock = $this->getMockBuilder(Auth0Service::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->guardAuthenticator = new JwtGuardAuthenticator($this->authZeroServiceMock);
+    }
+
+    /**
+     * Tests if JwtGuardAuthenticator::supports returns false when the Request does not contain an Authorization header.
+     */
+    public function testSupportsReturnsFalseWhenRequestDoesNotContainAuthorizationHeader()
+    {
+        $request = Request::create('/');
+
+        $this->assertFalse($this->guardAuthenticator->supports($request));
+    }
+
+    /**
+     * Tests if JwtGuardAuthenticator::supports returns true when the Request contains an Authorization header.
+     */
+    public function testSupportsReturnsTrueWhenRequestContainsAuthorizationHeader()
+    {
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+
+        $this->assertTrue($this->guardAuthenticator->supports($request));
+    }
+
+    /**
+     * Tests if JwtGuardAuthenticator::getCredentials returns null when the Request does not contain
+     * an Authorization header.
+     */
+    public function testGetCredentialsReturnsNullWhenRequestDoesNotContainAuthorizationHeader()
+    {
+        $request = Request::create('/');
+
+        $this->assertNull($this->guardAuthenticator->getCredentials($request));
+    }
+
+    /**
+     * Tests if JwtGuardAuthenticator::getCredentials returns an array with the 'jwt' key (that should
+     * contain the JWT token) when the Request contains an Authorization header.
+     */
+    public function testGetCredentialsReturnsArrayWithJwtWhenRequestContainsAuthorizationHeader()
+    {
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+
+        $this->assertSame(
+            array('jwt' => 'token'),
+            $this->guardAuthenticator->getCredentials($request)
+        );
+    }
+
+    /**
+     * Tests if JwtGuardAuthenticator::getUser return an unknown User instance when decoding the JSON Web Token fails,
+     * because verification of the token must be done during the JwtGuardAuthenticator::checkCredentials step.
+     */
+    public function testGetUserReturnsUnknownUserWhenJwtDecodingFails()
+    {
+        $this->authZeroServiceMock->expects($this->once())
+            ->method('decodeJWT')
+            ->with('invalidToken')
+            ->willThrowException(new InvalidTokenException('Malformed token.'));
+
+        $userProviderMock = $this->getMockBuilder(JWTUserProviderInterface::class)
+            ->getMock();
+        $userProviderMock->expects($this->never())
+            ->method('loadUserByJWT');
+        $userProviderMock->expects($this->never())
+            ->method('loadUserByUsername');
+
+        $user = $this->guardAuthenticator->getUser(
+            array('jwt' => 'invalidToken'),
+            $userProviderMock
+        );
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertSame('unknown', $user->getUsername());
+        $this->assertNull($user->getPassword());
+        $this->assertSame(array(), $user->getRoles());
+    }
+
+    /**
+     * Tests if JwtGuardAuthenticator::getUser calls the JWTUserProviderInterface::loadUserByJWT when the provided
+     * user provider implements the interface.
+     */
+    public function testGetUserReturnsUserThroughLoadUserByJWT()
+    {
+        $jwt = new stdClass();
+        $jwt->sub = 'authenticated-user';
+        $jwt->token = 'validToken';
+
+        $this->authZeroServiceMock->expects($this->once())
+            ->method('decodeJWT')
+            ->with('validToken')
+            ->willReturn($jwt);
+
+        $user = new User($jwt->sub, $jwt->token, array('ROLE_JWT_AUTHENTICATED'));
+
+        $userProviderMock = $this->getMockBuilder(JWTUserProviderInterface::class)
+            ->getMock();
+        $userProviderMock->expects($this->once())
+            ->method('loadUserByJWT')
+            ->with($jwt)
+            ->willReturn($user);
+
+        $returnedUser = $this->guardAuthenticator->getUser(
+            array('jwt' => 'validToken'),
+            $userProviderMock
+        );
+
+        $this->assertSame($user, $returnedUser);
+    }
+
+    /**
+     * Tests if JwtGuardAuthenticator::getUser calls the UserProviderInterface::loadUserByUsername when the provided
+     * user provider does not implement the JWTUserProviderInterface.
+     */
+    public function testGetUserReturnsUserThroughLoadUserByUsername()
+    {
+        $jwt = new stdClass();
+        $jwt->sub = 'authenticated-user';
+        $jwt->token = 'validToken';
+
+        $this->authZeroServiceMock->expects($this->once())
+            ->method('decodeJWT')
+            ->with('validToken')
+            ->willReturn($jwt);
+
+        $user = new User($jwt->sub, null, array('ROLE_JWT_AUTHENTICATED'));
+
+        $userProviderMock = $this->getMockBuilder(UserProviderInterface::class)
+            ->getMock();
+        $userProviderMock->expects($this->once())
+            ->method('loadUserByUsername')
+            ->with($jwt->sub)
+            ->willReturn($user);
+
+        $returnedUser = $this->guardAuthenticator->getUser(array('jwt' => 'validToken'), $userProviderMock);
+
+        $this->assertSame($user, $returnedUser);
+    }
+
+    /**
+     * Tests if JwtGuardAuthenticator::checkCredentials throws an AuthenticationException containing the information
+     * from the exception thrown by the Auth0Service.
+     */
+    public function testCheckCredentialsThrowsAuthenticationExceptionWhenJwtDecodingFails()
+    {
+        $this->authZeroServiceMock->expects($this->once())
+            ->method('decodeJWT')
+            ->with('invalidToken')
+            ->willThrowException(new InvalidTokenException('Malformed token.'));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Malformed token.');
+
+        $this->guardAuthenticator->checkCredentials(
+            array('jwt' => 'invalidToken'),
+            new User('unknown', null)
+        );
+    }
+
+    /**
+     * Tests if JwtGuardAuthenticator::checkCredentials returns true when decoding the JSON Web Token is successful.
+     */
+    public function testCheckCredentialsReturnsTrueWhenJwtDecodingSuccessful()
+    {
+        $this->authZeroServiceMock->expects($this->once())
+            ->method('decodeJWT')
+            ->with('validToken')
+            ->willReturn(new stdClass());
+
+        $this->assertTrue(
+            $this->guardAuthenticator->checkCredentials(
+                array('jwt' => 'validToken'),
+                new User('unknown', null)
+            )
+        );
+    }
+
+    /**
+     * Tests if JwtGuardAuthenticator::onAuthenticationSuccess does not return a Response, meaning the application will
+     * continue with the original request.
+     */
+    public function testOnAuthenticationSuccess()
+    {
+        $request = Request::create('/');
+
+        $tokenMock = $this->getMockBuilder(TokenInterface::class)
+            ->getMock();
+
+        $this->assertNull(
+            $this->guardAuthenticator->onAuthenticationSuccess($request, $tokenMock, 'providerKey')
+        );
+    }
+
+    /**
+     * Tests if JwtGuardAuthenticator::onAuthenticationFailure returns JSON response with a '403 Forbidden' status code.
+     */
+    public function testOnAuthenticationFailure()
+    {
+        $request = Request::create('/');
+        $exception = new AuthenticationException('Malformed token.', 0, new InvalidTokenException('Malformed token.'));
+
+        $response = $this->guardAuthenticator->onAuthenticationFailure($request, $exception);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(JsonResponse::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString(
+            '{"message": "Authentication failed: Malformed token."}',
+            $response->getContent()
+        );
+    }
+
+    /**
+     * Tests if JwtGuardAuthenticator::start returns a JSON response with a '401 Unauthorized' status code.
+     */
+    public function testStart()
+    {
+        $request = Request::create('/');
+
+        $response = $this->guardAuthenticator->start($request);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(JsonResponse::HTTP_UNAUTHORIZED, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString(
+            '{"message": "Authentication required."}',
+            $response->getContent()
+        );
+    }
+
+    /**
+     * Tests if JwtGuardAuthenticator::supportsRememberMe returns false. The Authorization header must be provided
+     * with every request.
+     */
+    public function testSupportsRememberMe()
+    {
+        $this->assertFalse($this->guardAuthenticator->supportsRememberMe());
+    }
+}

--- a/Tests/Security/Guard/JwtGuardAuthenticatorTest.php
+++ b/Tests/Security/Guard/JwtGuardAuthenticatorTest.php
@@ -18,8 +18,6 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 /**
  * Tests the @see JwtGuardAuthenticator.
- *
- * @author Niels Nijens <nijens.niels@gmail.com>
  */
 class JwtGuardAuthenticatorTest extends TestCase
 {

--- a/Tests/Security/Guard/JwtGuardAuthenticatorTest.php
+++ b/Tests/Security/Guard/JwtGuardAuthenticatorTest.php
@@ -27,20 +27,20 @@ class JwtGuardAuthenticatorTest extends TestCase
     private $guardAuthenticator;
 
     /**
-     * @var PHPUnit_Framework_MockObject_MockObject
+     * @var Auth0Service|PHPUnit_Framework_MockObject_MockObject
      */
-    private $authZeroServiceMock;
+    private $auth0Service;
 
     /**
      * Creates a JwtGuardAuthenticator instance for testing.
      */
     protected function setUp()
     {
-        $this->authZeroServiceMock = $this->getMockBuilder(Auth0Service::class)
+        $this->auth0Service = $this->getMockBuilder(Auth0Service::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->guardAuthenticator = new JwtGuardAuthenticator($this->authZeroServiceMock);
+        $this->guardAuthenticator = new JwtGuardAuthenticator($this->auth0Service);
     }
 
     /**
@@ -96,7 +96,7 @@ class JwtGuardAuthenticatorTest extends TestCase
      */
     public function testGetUserReturnsUnknownUserWhenJwtDecodingFails()
     {
-        $this->authZeroServiceMock->expects($this->once())
+        $this->auth0Service->expects($this->once())
             ->method('decodeJWT')
             ->with('invalidToken')
             ->willThrowException(new InvalidTokenException('Malformed token.'));
@@ -129,7 +129,7 @@ class JwtGuardAuthenticatorTest extends TestCase
         $jwt->sub = 'authenticated-user';
         $jwt->token = 'validToken';
 
-        $this->authZeroServiceMock->expects($this->once())
+        $this->auth0Service->expects($this->once())
             ->method('decodeJWT')
             ->with('validToken')
             ->willReturn($jwt);
@@ -161,7 +161,7 @@ class JwtGuardAuthenticatorTest extends TestCase
         $jwt->sub = 'authenticated-user';
         $jwt->token = 'validToken';
 
-        $this->authZeroServiceMock->expects($this->once())
+        $this->auth0Service->expects($this->once())
             ->method('decodeJWT')
             ->with('validToken')
             ->willReturn($jwt);
@@ -186,7 +186,7 @@ class JwtGuardAuthenticatorTest extends TestCase
      */
     public function testCheckCredentialsThrowsAuthenticationExceptionWhenJwtDecodingFails()
     {
-        $this->authZeroServiceMock->expects($this->once())
+        $this->auth0Service->expects($this->once())
             ->method('decodeJWT')
             ->with('invalidToken')
             ->willThrowException(new InvalidTokenException('Malformed token.'));
@@ -205,7 +205,7 @@ class JwtGuardAuthenticatorTest extends TestCase
      */
     public function testCheckCredentialsReturnsTrueWhenJwtDecodingSuccessful()
     {
-        $this->authZeroServiceMock->expects($this->once())
+        $this->auth0Service->expects($this->once())
             ->method('decodeJWT')
             ->with('validToken')
             ->willReturn(new stdClass());

--- a/Tests/Security/Guard/JwtGuardAuthenticatorTest.php
+++ b/Tests/Security/Guard/JwtGuardAuthenticatorTest.php
@@ -85,7 +85,7 @@ class JwtGuardAuthenticatorTest extends TestCase
         $request->headers->set('Authorization', 'Bearer token');
 
         $this->assertSame(
-            array('jwt' => 'token'),
+            ['jwt' => 'token'],
             $this->guardAuthenticator->getCredentials($request)
         );
     }
@@ -109,14 +109,14 @@ class JwtGuardAuthenticatorTest extends TestCase
             ->method('loadUserByUsername');
 
         $user = $this->guardAuthenticator->getUser(
-            array('jwt' => 'invalidToken'),
+            ['jwt' => 'invalidToken'],
             $userProviderMock
         );
 
         $this->assertInstanceOf(User::class, $user);
         $this->assertSame('unknown', $user->getUsername());
         $this->assertNull($user->getPassword());
-        $this->assertSame(array(), $user->getRoles());
+        $this->assertSame([], $user->getRoles());
     }
 
     /**
@@ -134,7 +134,7 @@ class JwtGuardAuthenticatorTest extends TestCase
             ->with('validToken')
             ->willReturn($jwt);
 
-        $user = new User($jwt->sub, $jwt->token, array('ROLE_JWT_AUTHENTICATED'));
+        $user = new User($jwt->sub, $jwt->token, ['ROLE_JWT_AUTHENTICATED']);
 
         $userProviderMock = $this->getMockBuilder(JWTUserProviderInterface::class)
             ->getMock();
@@ -144,7 +144,7 @@ class JwtGuardAuthenticatorTest extends TestCase
             ->willReturn($user);
 
         $returnedUser = $this->guardAuthenticator->getUser(
-            array('jwt' => 'validToken'),
+            ['jwt' => 'validToken'],
             $userProviderMock
         );
 
@@ -166,7 +166,7 @@ class JwtGuardAuthenticatorTest extends TestCase
             ->with('validToken')
             ->willReturn($jwt);
 
-        $user = new User($jwt->sub, null, array('ROLE_JWT_AUTHENTICATED'));
+        $user = new User($jwt->sub, null, ['ROLE_JWT_AUTHENTICATED']);
 
         $userProviderMock = $this->getMockBuilder(UserProviderInterface::class)
             ->getMock();
@@ -175,7 +175,7 @@ class JwtGuardAuthenticatorTest extends TestCase
             ->with($jwt->sub)
             ->willReturn($user);
 
-        $returnedUser = $this->guardAuthenticator->getUser(array('jwt' => 'validToken'), $userProviderMock);
+        $returnedUser = $this->guardAuthenticator->getUser(['jwt' => 'validToken'], $userProviderMock);
 
         $this->assertSame($user, $returnedUser);
     }
@@ -195,7 +195,7 @@ class JwtGuardAuthenticatorTest extends TestCase
         $this->expectExceptionMessage('Malformed token.');
 
         $this->guardAuthenticator->checkCredentials(
-            array('jwt' => 'invalidToken'),
+            ['jwt' => 'invalidToken'],
             new User('unknown', null)
         );
     }
@@ -212,7 +212,7 @@ class JwtGuardAuthenticatorTest extends TestCase
 
         $this->assertTrue(
             $this->guardAuthenticator->checkCredentials(
-                array('jwt' => 'validToken'),
+                ['jwt' => 'validToken'],
                 new User('unknown', null)
             )
         );

--- a/Tests/Security/User/JwtUserProviderTest.php
+++ b/Tests/Security/User/JwtUserProviderTest.php
@@ -11,8 +11,6 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Tests the @see JwtUserProvider.
- *
- * @author Niels Nijens <nijens.niels@gmail.com>
  */
 class JwtUserProviderTest extends TestCase
 {

--- a/Tests/Security/User/JwtUserProviderTest.php
+++ b/Tests/Security/User/JwtUserProviderTest.php
@@ -45,7 +45,7 @@ class JwtUserProviderTest extends TestCase
         $jwt->sub = 'username';
         $jwt->token = 'validToken';
 
-        $expectedUser = new User('username', 'validToken', array('ROLE_JWT_AUTHENTICATED'));
+        $expectedUser = new User('username', 'validToken', ['ROLE_JWT_AUTHENTICATED']);
 
         $this->assertEquals(
             $expectedUser,
@@ -62,7 +62,7 @@ class JwtUserProviderTest extends TestCase
         $jwt = new stdClass();
         $jwt->sub = 'username';
 
-        $expectedUser = new User('username', null, array('ROLE_JWT_AUTHENTICATED'));
+        $expectedUser = new User('username', null, ['ROLE_JWT_AUTHENTICATED']);
 
         $this->assertEquals(
             $expectedUser,
@@ -86,7 +86,7 @@ class JwtUserProviderTest extends TestCase
         $expectedUser = new User(
             'username',
             'validToken',
-            array('ROLE_JWT_AUTHENTICATED', 'ROLE_JWT_SCOPE_READ_MESSAGES', 'ROLE_JWT_SCOPE_WRITE_MESSAGES')
+            ['ROLE_JWT_AUTHENTICATED', 'ROLE_JWT_SCOPE_READ_MESSAGES', 'ROLE_JWT_SCOPE_WRITE_MESSAGES']
         );
 
         $this->assertEquals(
@@ -123,7 +123,7 @@ class JwtUserProviderTest extends TestCase
      */
     public function testRefreshUser()
     {
-        $user = new User('john.doe', 'validToken', array('ROLE_JWT_AUTHENTICATED'));
+        $user = new User('john.doe', 'validToken', ['ROLE_JWT_AUTHENTICATED']);
 
         $returnedUser = $this->userProvider->refreshUser($user);
 

--- a/Tests/Security/User/JwtUserProviderTest.php
+++ b/Tests/Security/User/JwtUserProviderTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Auth0\JWTAuthBundle\Security\User;
+
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Tests the @see JwtUserProvider.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class JwtUserProviderTest extends TestCase
+{
+    /**
+     * @var JwtUserProvider
+     */
+    private $userProvider;
+
+    /**
+     * Creates a JwtUserProvider instance for testing.
+     */
+    protected function setUp()
+    {
+        $this->userProvider = new JwtUserProvider();
+    }
+
+    /**
+     * Tests if JwtUserProvider::supportsClass returns true for the Symfony User class.
+     */
+    public function testSupportsClass()
+    {
+        $this->assertTrue($this->userProvider->supportsClass(User::class));
+    }
+
+    /**
+     * Tests if JwtUserProvider::loadUserByJWT returns the expected User instance created with information from
+     * the decoded JSON Web Token.
+     */
+    public function testLoadUserByJWT()
+    {
+        $jwt = new stdClass();
+        $jwt->sub = 'username';
+        $jwt->token = 'validToken';
+
+        $expectedUser = new User('username', 'validToken', array('ROLE_JWT_AUTHENTICATED'));
+
+        $this->assertEquals(
+            $expectedUser,
+            $this->userProvider->loadUserByJWT($jwt)
+        );
+    }
+
+    /**
+     * Tests if JwtUserProvider::loadUserByJWT returns the expected User instance created with information from
+     * the decoded JSON Web Token without token property.
+     */
+    public function testLoadUserByJWTWithoutTokenProperty()
+    {
+        $jwt = new stdClass();
+        $jwt->sub = 'username';
+
+        $expectedUser = new User('username', null, array('ROLE_JWT_AUTHENTICATED'));
+
+        $this->assertEquals(
+            $expectedUser,
+            $this->userProvider->loadUserByJWT($jwt)
+        );
+    }
+
+    /**
+     * Tests if JwtUserProvider::loadUserByJWT returns the expected User instance created with information from
+     * the decoded JSON Web Token.
+     *
+     * The scopes in the scope property will be transformed into Symfony compatible roles.
+     */
+    public function testLoadUserByJWTWithScopeProperty()
+    {
+        $jwt = new stdClass();
+        $jwt->sub = 'username';
+        $jwt->scope = 'read:messages write:messages';
+        $jwt->token = 'validToken';
+
+        $expectedUser = new User(
+            'username',
+            'validToken',
+            array('ROLE_JWT_AUTHENTICATED', 'ROLE_JWT_SCOPE_READ_MESSAGES', 'ROLE_JWT_SCOPE_WRITE_MESSAGES')
+        );
+
+        $this->assertEquals(
+            $expectedUser,
+            $this->userProvider->loadUserByJWT($jwt)
+        );
+    }
+
+    /**
+     * Tests if JwtUserProvider::getAnonymousUser returns nothing. Although, it must be implemented according
+     * to the JWTUserProviderInterface.
+     */
+    public function testGetAnonymousUser()
+    {
+        $this->assertNull($this->userProvider->getAnonymousUser());
+    }
+
+    /**
+     * Tests if JwtUserProvider::loadUserByUsername throws a UsernameNotFoundException with a message that
+     * the method should not be used.
+     */
+    public function testLoadUserByUsername()
+    {
+        $this->expectException(UsernameNotFoundException::class);
+        $this->expectExceptionMessage(
+            'Auth0\JWTAuthBundle\Security\User\JwtUserProvider cannot load user "john.doe" by username. Use Auth0\JWTAuthBundle\Security\User\JwtUserProvider::loadUserByJWT instead.'
+        );
+
+        $this->userProvider->loadUserByUsername('john.doe');
+    }
+
+    /**
+     * Tests if JwtUserProvider::refreshUser creates a new instance from the provided User instance.
+     */
+    public function testRefreshUser()
+    {
+        $user = new User('john.doe', 'validToken', array('ROLE_JWT_AUTHENTICATED'));
+
+        $returnedUser = $this->userProvider->refreshUser($user);
+
+        $this->assertNotSame($user, $returnedUser);
+        $this->assertEquals($user, $returnedUser);
+    }
+
+    /**
+     * Tests if JwtUserProvider::refreshUser throws an UnsupportedUserException when the provided instance
+     * is not of the class User.
+     */
+    public function testRefreshUserThrowsUnsupportedUserException()
+    {
+        $userMock = $this->getMockBuilder(UserInterface::class)
+            ->setMockClassName('UnsupportedUser')
+            ->getMock();
+
+        $this->expectException(UnsupportedUserException::class);
+        $this->expectExceptionMessage('Instances of "UnsupportedUser" are not supported.');
+
+        $this->userProvider->refreshUser($userMock);
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -12,3 +12,8 @@ services:
 
     jwt_auth.cache.file_system:
         class: Auth0\SDK\Helpers\Cache\FileSystemCacheHandler
+
+    jwt_auth.security.guard.jwt_guard_authenticator:
+        class: Auth0\JWTAuthBundle\Security\Guard\JwtGuardAuthenticator
+        arguments:
+            - "@jwt_auth.auth0_service"

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -17,3 +17,6 @@ services:
         class: Auth0\JWTAuthBundle\Security\Guard\JwtGuardAuthenticator
         arguments:
             - "@jwt_auth.auth0_service"
+
+    jwt_auth.security.user.jwt_user_provider:
+        class: Auth0\JWTAuthBundle\Security\User\JwtUserProvider

--- a/src/Security/Core/JWTUserProviderInterface.php
+++ b/src/Security/Core/JWTUserProviderInterface.php
@@ -2,6 +2,9 @@
 
 namespace Auth0\JWTAuthBundle\Security\Core;
 
+use stdClass;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 /**
@@ -15,7 +18,7 @@ interface JWTUserProviderInterface extends UserProviderInterface
      * This method must throw JWTInfoNotFoundException if the user is not
      * found.
      *
-     * @param string $jwt The decoded Json Web Token
+     * @param stdClass $jwt The decoded Json Web Token
      *
      * @return UserInterface
      *
@@ -36,5 +39,4 @@ interface JWTUserProviderInterface extends UserProviderInterface
      * @throws AuthenticationException
      */
     public function getAnonymousUser();
-
 }

--- a/src/Security/Guard/JwtGuardAuthenticator.php
+++ b/src/Security/Guard/JwtGuardAuthenticator.php
@@ -7,7 +7,6 @@ use Auth0\JWTAuthBundle\Security\Core\JWTUserProviderInterface;
 use Auth0\SDK\Exception\CoreException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\User;
@@ -142,7 +141,7 @@ class JwtGuardAuthenticator extends AbstractGuardAuthenticator
             ),
         );
 
-        return new JsonResponse($responseBody, Response::HTTP_FORBIDDEN);
+        return new JsonResponse($responseBody, JsonResponse::HTTP_UNAUTHORIZED);
     }
 
     /**
@@ -159,7 +158,7 @@ class JwtGuardAuthenticator extends AbstractGuardAuthenticator
             'message' => 'Authentication required.',
         );
 
-        return new JsonResponse($responseBody, Response::HTTP_UNAUTHORIZED);
+        return new JsonResponse($responseBody, JsonResponse::HTTP_UNAUTHORIZED);
     }
 
     /**

--- a/src/Security/Guard/JwtGuardAuthenticator.php
+++ b/src/Security/Guard/JwtGuardAuthenticator.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Auth0\JWTAuthBundle\Security\Guard;
+
+use Auth0\JWTAuthBundle\Security\Auth0Service;
+use Auth0\JWTAuthBundle\Security\Core\JWTUserProviderInterface;
+use Auth0\SDK\Exception\CoreException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
+
+/**
+ * Handles authentication with JSON Web Tokens through the 'Authorization' request header.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class JwtGuardAuthenticator extends AbstractGuardAuthenticator
+{
+    /**
+     * @var Auth0Service
+     */
+    private $authZeroService;
+
+    /**
+     * Constructs a new JwtGuardAuthenticator instance.
+     *
+     * @param Auth0Service $authZeroService
+     */
+    public function __construct(Auth0Service $authZeroService)
+    {
+        $this->authZeroService = $authZeroService;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request)
+    {
+        return $request->headers->has('Authorization');
+    }
+
+    /**
+     * Retrieves the authentication credentials from the 'Authorization' request header.
+     *
+     * @param Request $request
+     *
+     * @return array|null
+     */
+    public function getCredentials(Request $request)
+    {
+        // Removes the 'Bearer ' part from the Authorization header value.
+        $jwt = substr($request->headers->get('Authorization', ''), 7);
+        if (empty($jwt)) {
+            return null;
+        }
+
+        return array(
+            'jwt' => $jwt,
+        );
+    }
+
+    /**
+     * Returns a user based on the information inside the JSON Web Token depending on the implementation
+     * of the configured user provider.
+     *
+     * When the user provider does not implement the JWTUserProviderInterface it will attempt to load
+     * the user by username with the 'sub' (subject) claim of the JSON Web Token.
+     *
+     * @param array                 $credentials
+     * @param UserProviderInterface $userProvider
+     *
+     * @return UserInterface|null
+     */
+    public function getUser($credentials, UserProviderInterface $userProvider)
+    {
+        try {
+            $jwt = $this->authZeroService->decodeJWT($credentials['jwt']);
+        } catch (CoreException $exception) {
+            // Skip JWT verification exceptions here.
+            // Verification will be done in checkCredentials().
+            return new User('unknown', null, array());
+        }
+
+        if ($userProvider instanceof JWTUserProviderInterface) {
+            return $userProvider->loadUserByJWT($jwt);
+        }
+
+        return $userProvider->loadUserByUsername($jwt->sub);
+    }
+
+    /**
+     * Returns true when the provided JSON Web Token successfully decodes and validates.
+     *
+     * @param array         $credentials
+     * @param UserInterface $user
+     *
+     * @return bool
+     *
+     * @throws AuthenticationException when decoding and/or validation of the JSON Web Token fails
+     */
+    public function checkCredentials($credentials, UserInterface $user)
+    {
+        try {
+            $this->authZeroService->decodeJWT($credentials['jwt']);
+
+            return true;
+        } catch (CoreException $exception) {
+            throw new AuthenticationException($exception->getMessage(), $exception->getCode(), $exception);
+        }
+    }
+
+    /**
+     * Returns nothing to continue the request when authenticated.
+     *
+     * @param Request        $request
+     * @param TokenInterface $token
+     * @param string         $providerKey
+     */
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
+    {
+        // Continue with request.
+    }
+
+    /**
+     * Returns the 'Authentication failed' response.
+     *
+     * @param Request                 $request
+     * @param AuthenticationException $exception
+     *
+     * @return JsonResponse
+     */
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    {
+        $responseBody = array(
+            'message' => sprintf(
+                'Authentication failed: %s.',
+                rtrim($exception->getMessage(), '.')
+            ),
+        );
+
+        return new JsonResponse($responseBody, Response::HTTP_FORBIDDEN);
+    }
+
+    /**
+     * Returns a response that directs the user to authenticate.
+     *
+     * @param Request                 $request
+     * @param AuthenticationException $authenticationException
+     *
+     * @return JsonResponse
+     */
+    public function start(Request $request, AuthenticationException $authenticationException = null)
+    {
+        $responseBody = array(
+            'message' => 'Authentication required.',
+        );
+
+        return new JsonResponse($responseBody, Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsRememberMe()
+    {
+        return false;
+    }
+}

--- a/src/Security/Guard/JwtGuardAuthenticator.php
+++ b/src/Security/Guard/JwtGuardAuthenticator.php
@@ -39,7 +39,8 @@ class JwtGuardAuthenticator extends AbstractGuardAuthenticator
      */
     public function supports(Request $request)
     {
-        return $request->headers->has('Authorization');
+        return $request->headers->has('Authorization') &&
+               strpos($request->headers->get('Authorization'), 'Bearer') === 0;
     }
 
     /**

--- a/src/Security/Guard/JwtGuardAuthenticator.php
+++ b/src/Security/Guard/JwtGuardAuthenticator.php
@@ -52,7 +52,7 @@ class JwtGuardAuthenticator extends AbstractGuardAuthenticator
     public function getCredentials(Request $request)
     {
         // Removes the 'Bearer ' part from the Authorization header value.
-        $jwt = substr($request->headers->get('Authorization', ''), 7);
+        $jwt = str_replace('Bearer ', '', $request->headers->get('Authorization', ''));
         if (empty($jwt)) {
             return null;
         }

--- a/src/Security/Guard/JwtGuardAuthenticator.php
+++ b/src/Security/Guard/JwtGuardAuthenticator.php
@@ -22,16 +22,16 @@ class JwtGuardAuthenticator extends AbstractGuardAuthenticator
     /**
      * @var Auth0Service
      */
-    private $authZeroService;
+    private $auth0Service;
 
     /**
      * Constructs a new JwtGuardAuthenticator instance.
      *
-     * @param Auth0Service $authZeroService
+     * @param Auth0Service $auth0Service
      */
-    public function __construct(Auth0Service $authZeroService)
+    public function __construct(Auth0Service $auth0Service)
     {
-        $this->authZeroService = $authZeroService;
+        $this->auth0Service = $auth0Service;
     }
 
     /**
@@ -77,7 +77,7 @@ class JwtGuardAuthenticator extends AbstractGuardAuthenticator
     public function getUser($credentials, UserProviderInterface $userProvider)
     {
         try {
-            $jwt = $this->authZeroService->decodeJWT($credentials['jwt']);
+            $jwt = $this->auth0Service->decodeJWT($credentials['jwt']);
         } catch (CoreException $exception) {
             // Skip JWT verification exceptions here.
             // Verification will be done in checkCredentials().
@@ -104,7 +104,7 @@ class JwtGuardAuthenticator extends AbstractGuardAuthenticator
     public function checkCredentials($credentials, UserInterface $user)
     {
         try {
-            $this->authZeroService->decodeJWT($credentials['jwt']);
+            $this->auth0Service->decodeJWT($credentials['jwt']);
 
             return true;
         } catch (CoreException $exception) {

--- a/src/Security/Guard/JwtGuardAuthenticator.php
+++ b/src/Security/Guard/JwtGuardAuthenticator.php
@@ -57,9 +57,9 @@ class JwtGuardAuthenticator extends AbstractGuardAuthenticator
             return null;
         }
 
-        return array(
+        return [
             'jwt' => $jwt,
-        );
+        ];
     }
 
     /**
@@ -81,7 +81,7 @@ class JwtGuardAuthenticator extends AbstractGuardAuthenticator
         } catch (CoreException $exception) {
             // Skip JWT verification exceptions here.
             // Verification will be done in checkCredentials().
-            return new User('unknown', null, array());
+            return new User('unknown', null, []);
         }
 
         if ($userProvider instanceof JWTUserProviderInterface) {
@@ -134,12 +134,12 @@ class JwtGuardAuthenticator extends AbstractGuardAuthenticator
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
-        $responseBody = array(
+        $responseBody = [
             'message' => sprintf(
                 'Authentication failed: %s.',
                 rtrim($exception->getMessage(), '.')
             ),
-        );
+        ];
 
         return new JsonResponse($responseBody, JsonResponse::HTTP_UNAUTHORIZED);
     }
@@ -154,9 +154,9 @@ class JwtGuardAuthenticator extends AbstractGuardAuthenticator
      */
     public function start(Request $request, AuthenticationException $authenticationException = null)
     {
-        $responseBody = array(
+        $responseBody = [
             'message' => 'Authentication required.',
-        );
+        ];
 
         return new JsonResponse($responseBody, JsonResponse::HTTP_UNAUTHORIZED);
     }

--- a/src/Security/Guard/JwtGuardAuthenticator.php
+++ b/src/Security/Guard/JwtGuardAuthenticator.php
@@ -17,8 +17,6 @@ use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
 
 /**
  * Handles authentication with JSON Web Tokens through the 'Authorization' request header.
- *
- * @author Niels Nijens <nijens.niels@gmail.com>
  */
 class JwtGuardAuthenticator extends AbstractGuardAuthenticator
 {

--- a/src/Security/User/JwtUserProvider.php
+++ b/src/Security/User/JwtUserProvider.php
@@ -81,9 +81,9 @@ class JwtUserProvider implements JWTUserProviderInterface
     private function getRoles(stdClass $jwt)
     {
         return array_merge(
-            array(
+            [
                 'ROLE_JWT_AUTHENTICATED',
-            ),
+            ],
             $this->getScopesFromJwtAsRoles($jwt)
         );
     }
@@ -98,13 +98,13 @@ class JwtUserProvider implements JWTUserProviderInterface
     private function getScopesFromJwtAsRoles(stdClass $jwt)
     {
         if (isset($jwt->scope) === false) {
-            return array();
+            return [];
         }
 
         $scopes = explode(' ', $jwt->scope);
         $roles = array_map(
             function ($scope) {
-                $roleSuffix = strtoupper(str_replace(array(':', '-'), '_', $scope));
+                $roleSuffix = strtoupper(str_replace([':', '-'], '_', $scope));
 
                 return sprintf('ROLE_JWT_SCOPE_%s', $roleSuffix);
             },

--- a/src/Security/User/JwtUserProvider.php
+++ b/src/Security/User/JwtUserProvider.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Auth0\JWTAuthBundle\Security\User;
+
+use Auth0\JWTAuthBundle\Security\Core\JWTUserProviderInterface;
+use stdClass;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Basic JWT UserProvider implementation when you do not require loading the user from the database and
+ * the JWT verification with Auth0 is enough for your use-case.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class JwtUserProvider implements JWTUserProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsClass($class)
+    {
+        return $class === User::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadUserByJWT($jwt)
+    {
+        $token = null;
+        if (isset($jwt->token)) {
+            $token = $jwt->token;
+        }
+
+        return new User($jwt->sub, $token, $this->getRoles($jwt));
+    }
+
+    /**
+     * Unused by the @see JwtGuardAuthenticator.
+     */
+    public function getAnonymousUser()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadUserByUsername($username)
+    {
+        throw new UsernameNotFoundException(
+            sprintf(
+                '%1$s cannot load user "%2$s" by username. Use %1$s::loadUserByJWT instead.',
+                __CLASS__,
+                $username
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refreshUser(UserInterface $user)
+    {
+        if ($user instanceof User === false) {
+            throw new UnsupportedUserException(
+                sprintf('Instances of "%s" are not supported.', get_class($user))
+            );
+        }
+
+        return new User($user->getUsername(), $user->getPassword(), $user->getRoles());
+    }
+
+    /**
+     * Returns the roles for the user.
+     *
+     * @param stdClass $jwt
+     *
+     * @return array
+     */
+    private function getRoles(stdClass $jwt)
+    {
+        return array_merge(
+            array(
+                'ROLE_JWT_AUTHENTICATED',
+            ),
+            $this->getScopesFromJwtAsRoles($jwt)
+        );
+    }
+
+    /**
+     * Returns the scopes from the JSON Web Token as Symfony roles prefixed with 'ROLE_JWT_SCOPE_'.
+     *
+     * @param stdClass $jwt
+     *
+     * @return array
+     */
+    private function getScopesFromJwtAsRoles(stdClass $jwt)
+    {
+        $roles = array();
+
+        if (isset($jwt->scope)) {
+            $scopes = explode(' ', $jwt->scope);
+
+            $roles = array_map(
+                function ($scope) {
+                    $roleSuffix = strtoupper(str_replace(array(':', '-'), '_', $scope));
+
+                    return sprintf('ROLE_JWT_SCOPE_%s', $roleSuffix);
+                },
+                $scopes
+            );
+        }
+
+        return $roles;
+    }
+}

--- a/src/Security/User/JwtUserProvider.php
+++ b/src/Security/User/JwtUserProvider.php
@@ -11,9 +11,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Basic JWT UserProvider implementation when you do not require loading the user from the database and
- * the JWT verification with Auth0 is enough for your use-case.
- *
- * @author Niels Nijens <nijens.niels@gmail.com>
+ * the JWT verification with Auth0 is enough for your use-case. Eg. Machine-to-Machine authentication.
  */
 class JwtUserProvider implements JWTUserProviderInterface
 {

--- a/src/Security/User/JwtUserProvider.php
+++ b/src/Security/User/JwtUserProvider.php
@@ -97,20 +97,19 @@ class JwtUserProvider implements JWTUserProviderInterface
      */
     private function getScopesFromJwtAsRoles(stdClass $jwt)
     {
-        $roles = array();
-
-        if (isset($jwt->scope)) {
-            $scopes = explode(' ', $jwt->scope);
-
-            $roles = array_map(
-                function ($scope) {
-                    $roleSuffix = strtoupper(str_replace(array(':', '-'), '_', $scope));
-
-                    return sprintf('ROLE_JWT_SCOPE_%s', $roleSuffix);
-                },
-                $scopes
-            );
+        if (isset($jwt->scope) === false) {
+            return array();
         }
+
+        $scopes = explode(' ', $jwt->scope);
+        $roles = array_map(
+            function ($scope) {
+                $roleSuffix = strtoupper(str_replace(array(':', '-'), '_', $scope));
+
+                return sprintf('ROLE_JWT_SCOPE_%s', $roleSuffix);
+            },
+            $scopes
+        );
 
         return $roles;
     }


### PR DESCRIPTION
The current `SimplePreAuthenticator` implementation is deprecated since Symfony 4.2. The guard authentication system provides more flexibility to eg. more verbose responses concerning authentication. And it makes this bundle (better) forward-compatible with Symfony 5 and later.

This PR adds the following:
* A `JwtGuardAuthenticator` class with service definition to use in the `security.y(a)ml`.
* A `JwtUserProvider` which adheres to the `JWTUserProviderInterface`. It offers a basic user provider implementation by reading the information from the token and transforming it to a Symfony `User`.
* A docblock fix for `JWTUserProviderInterface::loadUserByJWT`.

At the moment the `JwtGuardAuthenticator` returns JSON responses, but I guess not everyone would want that.

If you'd like to provide more flexibility, I'm willing to extract that part from the guard authenticator.

### References
- Guard authenticators are supported since [Symfony 2.8 (source: Packagist)](https://packagist.org/packages/symfony/security-guard#v2.8.0)
- [SimplePreAuthenticator implementation is deprecated since Symfony 4.2](https://symfony.com/blog/symfony-4-2-curated-new-features#security)

### Testing
Instead of following chapter "Set up the SecurityProvider" of the [Symfony API: Authorization](https://auth0.com/docs/quickstart/backend/symfony#set-up-the-securityprovider) guide add the following configuration to the `security.y(a)ml`:
```yaml
security:
    providers:
        a0:
            id: jwt_auth.security.user.jwt_user_provider

    firewalls:
        secured_area:
            pattern: ^/api
            stateless: true
            provider: 'a0'
            guard:
                authenticators:
                    - jwt_auth.security.guard.jwt_guard_authenticator

    access_control:
        - { path: ^/api/private-scoped, roles: ROLE_JWT_SCOPE_READ_MESSAGES }
        - { path: ^/api/private, roles: ROLE_JWT_AUTHENTICATED }
        - { path: ^/api/public, roles: IS_AUTHENTICATED_ANONYMOUSLY }
```

Optionally, chapter "Set up the User and UserProvider" can also be skipped by configuring the `JwtUserProvider`.

- [x] This change adds test coverage
- [x] This change has been tested on Symfony 4.2
- [ ] This change has been tested on the latest version of Symfony

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
