### PR TITLE
Fixed deprecated root call

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@auth0/sdk-team-approvers

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('jwt_auth');
+        $treeBuilder = new TreeBuilder('jwt_auth');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()


### PR DESCRIPTION
### Changes

Fixed deprecated call with Symfony >= 4.3 

 The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "jwt_auth" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.

