### PR TITLE
Fix deprecation Treebuilder::root

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,9 +16,9 @@ class Configuration implements ConfigurationInterface
      * {@inheritdoc}
      */
     public function getConfigTreeBuilder()
-    {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('jwt_auth');
+    {   
+        $treeBuilder = new TreeBuilder('jwt_auth');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('jwt_auth');
 
         $rootNode
             ->children()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ class Configuration implements ConfigurationInterface
      * {@inheritdoc}
      */
     public function getConfigTreeBuilder()
-    {   
+    {
         $treeBuilder = new TreeBuilder('jwt_auth');
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('jwt_auth');
 


### PR DESCRIPTION
Fix for the following:

`The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "jwt_auth" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.`

It's fixed in a BC way. From: https://github.com/symfony/monolog-bundle/pull/281/commits/45742f1a97291edd1401ecb58024488bbd793038

