### PR TITLE
Configuration authorized_issuer string or array compatibility

### DIFF
--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Auth0\JWTAuthBundle\Tests\DependencyInjection;
+
+use Auth0\JWTAuthBundle\DependencyInjection\JWTAuthExtension;
+use Auth0\JWTAuthBundle\JWTAuthBundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var JWTAuthBundle  */
+    private $extension;
+    /** @var ContainerBuilder  */
+    private $container;
+    /** @var string  */
+    private $rootNode;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->extension = new JWTAuthExtension();
+        $this->container = new ContainerBuilder();
+        $this->rootNode = 'jwt_auth';
+    }
+
+    public function testGetConfigWhenMultipleApiIdentifier()
+    {
+        $configs = [
+            'api_identifier_array' => [
+                'test identifier1',
+                'test identifier2'
+            ],
+            'api_client_id' => 'test client id'
+        ];
+
+        $this->extension->load([$configs], $this->container);
+
+        $this->assertTrue($this->container->hasParameter($this->rootNode . '.api_identifier'));
+        $this->assertEquals(
+            [
+                'test identifier1',
+                'test identifier2',
+                'test client id'
+            ],
+            $this->container->getParameter($this->rootNode . '.api_identifier')
+        );
+    }
+
+    public function testGetConfigWhenSingleApiIdentifier()
+    {
+        $configs = [
+            'api_identifier' => 'test identifier'
+        ];
+
+        $this->extension->load([$configs], $this->container);
+
+        $this->assertTrue($this->container->hasParameter($this->rootNode . '.api_identifier'));
+        $this->assertEquals('test identifier', $this->container->getParameter($this->rootNode . '.api_identifier'));
+    }
+
+    public function testGetConfigWhenMultipleAuthorizedIssuer()
+    {
+        $configs = [
+            'authorized_issuer' => [
+                'test authorized issuer1',
+                'test authorized issuer2'
+            ]
+        ];
+
+        $this->extension->load([$configs], $this->container);
+
+        $this->assertTrue($this->container->hasParameter($this->rootNode . '.authorized_issuer'));
+        $this->assertEquals(
+            [
+                'test authorized issuer1',
+                'test authorized issuer2'
+            ],
+            $this->container->getParameter($this->rootNode . '.authorized_issuer')
+        );
+    }
+
+    public function testGetConfigWhenSingleAuthorizedIssuer()
+    {
+        $configs = [
+            'authorized_issuer' => 'test authorized issuer'
+        ];
+
+        $this->extension->load([$configs], $this->container);
+
+        $this->assertTrue($this->container->hasParameter($this->rootNode . '.authorized_issuer'));
+        $this->assertEquals('test authorized issuer', $this->container->getParameter($this->rootNode . '.authorized_issuer'));
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('api_identifier_array')
                 ->prototype('scalar')->end()
             ->end()
-            ->scalarNode('authorized_issuer')->defaultValue('')->end()
+            ->variableNode('authorized_issuer')->defaultValue([])->end()
             ->arrayNode('supported_algs')
                 ->addDefaultChildrenIfNoneSet(1)
                 ->prototype('scalar')


### PR DESCRIPTION
### Changes

Fix **BC** introduced in last PR. Now the `authorized_issuer` can really be a string or an array. I also added tests to the `Configuration`

### Testing

[x] This change adds test coverage
[x] All existing and new tests complete without errors
