### PR TITLE
Add support for autowiring

### DIFF
--- a/Tests/Functional/BundleInitializationTest.php
+++ b/Tests/Functional/BundleInitializationTest.php
@@ -27,6 +27,11 @@ class BundleInitializationTest extends BaseBundleTestCase
         $this->assertTrue($container->has('jwt_auth.auth0_service'));
         $service = $container->get('jwt_auth.auth0_service');
         $this->assertInstanceOf(Auth0Service::class, $service);
+
+        // Test if autowiring is working properly
+        $this->assertTrue($container->has(Auth0Service::class));
+        $service = $container->get(Auth0Service::class);
+        $this->assertInstanceOf(Auth0Service::class, $service);
     }
 
     public function testBundleWithCache()

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -3,6 +3,9 @@ services:
         class: Auth0\JWTAuthBundle\Security\Auth0Service
         arguments: ["%jwt_auth.api_secret%","%jwt_auth.domain%","%jwt_auth.api_identifier%","%jwt_auth.authorized_issuer%","%jwt_auth.secret_base64_encoded%", "%jwt_auth.supported_algs%", ~]
 
+    Auth0\JWTAuthBundle\Security\Auth0Service:
+        alias: jwt_auth.auth0_service
+
     jwt_auth.jwt_authenticator:
         class:     Auth0\JWTAuthBundle\Security\JWTAuthenticator
         arguments: ["@jwt_auth.auth0_service"]


### PR DESCRIPTION
### Changes

Allow to autowire the `Auth0Service` service.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

[x] This change adds test coverage

[x] This change has been tested on the latest version of Symfony

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
