### PR TITLE
Give access to the raw JWT in the user provider

### DIFF
--- a/src/Security/Core/RawTokenAwareJWTUserProviderInterface.php
+++ b/src/Security/Core/RawTokenAwareJWTUserProviderInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Auth0\JWTAuthBundle\Security\Core;
+
+/**
+ * Gives access to the raw JWT.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+interface RawTokenAwareJWTUserProviderInterface extends JWTUserProviderInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @param string|null $rawToken The raw (not decoded) token.
+     */
+    public function loadUserByJWT($jwt, $rawToken = null);
+}

--- a/src/Security/Guard/JwtGuardAuthenticator.php
+++ b/src/Security/Guard/JwtGuardAuthenticator.php
@@ -86,7 +86,7 @@ class JwtGuardAuthenticator extends AbstractGuardAuthenticator
         }
 
         if ($userProvider instanceof JWTUserProviderInterface) {
-            return $userProvider->loadUserByJWT($jwt);
+            return $userProvider->loadUserByJWT($jwt, $credentials['jwt']);
         }
 
         return $userProvider->loadUserByUsername($jwt->sub);


### PR DESCRIPTION
### Changes

Adds a new interface allowing a user provider to access to the raw JWT. It is useful, for instance, to call the the `/userinfo` endpoint to get the email of the user in the provider.

According to the code, it looks like the `$jwt` object used to have a `token` property containing the raw token, but it isn't set anymore (if it already has been) by current versions of Firebase JWT.

See also #97 for a less intrusive implementation.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

[x] This change adds test coverage

[x] This change has been tested on the latest version of Symfony

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
