### PR TITLE
Give access to the raw JWT in the user provider (alternative implem)

### DIFF
--- a/src/Security/Guard/JwtGuardAuthenticator.php
+++ b/src/Security/Guard/JwtGuardAuthenticator.php
@@ -85,6 +85,10 @@ class JwtGuardAuthenticator extends AbstractGuardAuthenticator
             return new User('unknown', null, []);
         }
 
+        if (!isset($jwt->token)) {
+            $jwt->token = $credentials['jwt'];
+        }
+
         if ($userProvider instanceof JWTUserProviderInterface) {
             return $userProvider->loadUserByJWT($jwt);
         }


### PR DESCRIPTION
### Changes

Alternative to #96 (same rationale). This implementation is less intrusive.
Always populate the `token` property of the JWT object.

### References

#96.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

[x] This change adds test coverage

[x] This change has been tested on the latest version of Symfony

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
