### PR TITLE
Fix codecov reporting invalid SHA1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
     steps:
       - run: ./vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml
       - run: 
-          command: bash <(curl -s https://codecov.io/bash)
+          command: bash <(curl -s https://codecov.io/bash) -Z -C $CIRCLE_SHA1
           when: on_success
 
 jobs: 


### PR DESCRIPTION
### Changes

This will fix codecov not being able to upload reports after rebasing a PR from the GH UI.
