### PR TITLE
Remove broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ composer require auth0/jwt-auth-bundle:"~3.0"
 
 > For more information about Composer usage, check [their official documentation](https://getcomposer.org/doc/00-intro.md).
 
-## Resources
-
-Check out the [Symfony API QuickStart Guide](https://auth0.com/docs/quickstart/backend/symfony) to find out more about integrating the bundle into an existing project or download a pre-configured project.
-
 ## Demo
 
 [Symfony API Samples](https://github.com/auth0-community/auth0-symfony-api-samples)


### PR DESCRIPTION
### Changes

Remove the broken link to the now removed Symfony API Quickstart. This was raised in #91

### Checklist

[X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[X] All existing and new tests complete without errors
