### PR TITLE
fix: set same return type as interface

### DIFF
--- a/src/Security/User/JwtUserProvider.php
+++ b/src/Security/User/JwtUserProvider.php
@@ -32,7 +32,7 @@ class JwtUserProvider implements JWTUserProviderInterface
      *
      * @param stdClass $jwt An encoded JWT.
      *
-     * @return User
+     * @return UserInterface
      */
     public function loadUserByJWT(stdClass $jwt)
     {


### PR DESCRIPTION
### Changes

This small fix changes the return type of the `loadUserByJWT` function from `Symfony\Component\Security\Core\User\User` to 
`Symfony\Component\Security\Core\User\UserInterface`. 

This also makes it easier to extend the `Auth0\JWTAuthBundle\Security\User\JwtUserProvider` class when creating your own provider.

### References

- In the `JWTUserProviderInterface`, the `loadUserByJWT` function returns a `UserInterface`.
- In the `JwtUserProvider` class which implements `JWTUserProviderInterface`, the `loadUserByJWT` function returns a `Symfony\Component\Security\Core\User\User`.
- In the `JwtGuardAuthenticator` class in the function `getUser`, the `loadUserByJWT` of the `JwtUserProvider` is called and expects an instance of `UserInterface`.

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[ ] All existing and new tests complete without errors
