### PR TITLE
[SDK-2377] Add optional validator for `org_id` on tokens, for Organizations support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ jwt_auth:
     aud: "%env(AUTH0_API_AUDIENCE)%"
     # Validate the AZP claim against a value, such as a client ID. Set to false to skip. Defaults to false.
     azp: "%env(AUTH0_CLIENT_ID)%"
+    # Validate ORG_ID claim against a value, such as the Auth0 Organization. Set to false to skip. Defaults to false.
+    org_id: "%env(AUTH0_ORGANIZATION)%"
     # Maximum age (in seconds) since the auth_time of the token. Set to false to skip. Defaults to false.
     max_age: 3600
     # Clock tolerance (in seconds) for token expiration checks. Requires an integer value. Defaults to 60 seconds.

--- a/Tests/Security/Helpers/JwtValidationsTest.php
+++ b/Tests/Security/Helpers/JwtValidationsTest.php
@@ -18,6 +18,7 @@ class JwtValidationsTest extends TestCase
         $this->token = [
           'nonce'     => 'test_nonce',
           'azp'       => 'test_azp',
+          'org_id'    => 'test_org',
           'aud'       => [
             'first_audience',
             'second_audience'
@@ -125,6 +126,29 @@ class JwtValidationsTest extends TestCase
       $token = $this->token;
       $token['aud'] = 'string_audience';
       $this->assertTrue(JwtValidations::validateClaimAud('string_audience', $token));
+    }
+
+    /*
+    Org_id Validations
+    */
+
+    public function testValidateClaimOrgIdMatching() {
+      $this->assertTrue(JwtValidations::validateClaimOrgId('test_org', $this->token));
+    }
+    public function testValidateClaimOrgIdMismatch() {
+      $this->expectException(InvalidTokenException::class);
+      $this->expectExceptionMessage('Organization Id (org_id) claim value mismatch in the ID token; expected "invalid_org", found "test_org"');
+
+      JwtValidations::validateClaimOrgId('invalid_org', $this->token);
+    }
+    public function testValidateClaimOrgIdMissing() {
+      $this->expectException(InvalidTokenException::class);
+      $this->expectExceptionMessage('Organization Id (org_id) claim must be a string present in the ID token');
+
+      $token = $this->token;
+      unset($token['org_id']);
+
+      JwtValidations::validateClaimOrgId('test_org', $token);
     }
 
     /*

--- a/src/DependencyInjection/JWTAuthExtension.php
+++ b/src/DependencyInjection/JWTAuthExtension.php
@@ -46,6 +46,7 @@ class JWTAuthExtension extends Extension
         }
 
         $validations = [
+            'org_id' => null,
             'azp' => null,
             'aud' => $config['audience'],
             'leeway' => 60,
@@ -72,6 +73,16 @@ class JWTAuthExtension extends Extension
                     }
                 } else {
                     $validations['aud'] = null;
+                }
+            }
+
+            if (array_key_exists('org_id', $config['validations'])) {
+                if (! empty($config['validations']['org_id'])) {
+                    if (true !== $config['validations']['org_id']) {
+                        $validations['org_id'] = $config['validations']['org_id'];
+                    }
+                } else {
+                    $validations['org_id'] = null;
                 }
             }
 

--- a/src/Security/Helpers/JwtValidations.php
+++ b/src/Security/Helpers/JwtValidations.php
@@ -26,6 +26,7 @@ class JwtValidations
         self::validateClaimNonce($claims['nonce'] ?? null, $token);
         self::validateClaimAzp($claims['azp'] ?? null, $token);
         self::validateClaimAud($claims['aud'] ?? null, $token);
+        self::validateClaimAud($claims['org_id'] ?? null, $token);
 
         return true;
     }
@@ -123,6 +124,37 @@ class JwtValidations
                 throw new InvalidTokenException( sprintf(
                   'Audience (aud) claim mismatch; expected "%s"',
                   $aud
+                ));
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if a token includes a org_id claim and that it contains an expected value.
+     *
+     * @param null|string         $aud   A value expected inside the token audience.
+     * @param array<string,mixed> $token An array representing data from a decoded JWT.
+     *
+     * @return boolean
+     *
+     * @throws InvalidTokenException When token claim validation fails.
+     */
+    public static function validateClaimOrgId(?string $orgId = null, array $token = []): bool
+    {
+        if (null !== $orgId) {
+            $tokenOrgId = $token['org_id'] ?? null;
+
+            if (! $tokenOrgId || ! is_string($tokenOrgId)) {
+                throw new InvalidTokenException('Organization Id (org_id) claim must be a string present in the ID token');
+            }
+
+            if ($tokenOrgId !== $orgId) {
+                throw new InvalidTokenException(sprintf(
+                    'Organization Id (org_id) claim value mismatch in the ID token; expected "%s", found "%s"',
+                    $orgId,
+                    $tokenOrgId
                 ));
             }
         }


### PR DESCRIPTION
This PR adds support for validating an `org_id` claim on a JWT, necessary for Organizations (currently in a closed beta) support.

A new configuration variable is available:

```yaml
jwt_auth:
  validations:
    # Validate ORG_ID claim against a value, such as the Auth0 Organization. Set to false to skip. Defaults to false.
    org_id: "%env(AUTH0_ORGANIZATION)%"
```

This will ensure the the `org_id` claim on a provided token matches the supplied value.

- PR adds `Auth0\JWTAuthBundle\Security\Helpers\JwtValidations::validateClaimAzp()` for processing this validation
- PR updates `Auth0\JWTAuthBundle\Security\Helpers\JwtValidations::validateClaims()` to trigger the validation during `Auth0\JWTAuthBundle\Security\Auth0Service::decodeJWT()` calls
- Adds tests around the new validation