### PR TITLE
Fix JwtGuardAuthenticator::supports behavior to avoid conflicting with other bundles

### DIFF
--- a/src/Security/Guard/JwtGuardAuthenticator.php
+++ b/src/Security/Guard/JwtGuardAuthenticator.php
@@ -49,7 +49,8 @@ class JwtGuardAuthenticator extends AbstractGuardAuthenticator
     // phpcs:ignore
     public function supports(Request $request)
     {
-        return true;
+        return $request->headers->has('Authorization') &&
+               strpos($request->headers->get('Authorization'), 'Bearer') === 0;
     }
 
     /**


### PR DESCRIPTION
It was brought to my attention that a change in the previous commit around PHP 8 support and PHP SDK updates would result in this bundle conflicting with other Guard bundles. This PR restores the behavior of the Authentication Bearer header check so that our bundle can co-exist with other Guard bundles.