### PR TITLE
WIP - Support new Symfony authenticator system

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ jwt_auth:
     leeway: 60
 ```
 
+Sample for `config/security.yaml`
+```
+security:
+    # The option below is required if you want to use the jwt_auth.security.guard.jwt_authenticator service (Sf >= 5.1)
+    enable_authenticator_manager: true
+    firewalls:
+        main:
+            pattern:   ^/
+            provider: web_service_user_provider
+            # For Symfony >= 5.1
+            custom_authenticators:
+                - jwt_auth.security.guard.jwt_authenticator  
+            # For Symfony < 5.1
+            guard:
+                authenticators:
+                    - jwt_auth.security.guard.jwt_guard_authenticator
+            
+```
+
 ## Demo
 
 [Symfony API Samples](https://github.com/auth0-community/auth0-symfony-api-samples)

--- a/Tests/Security/Guard/JwtAuthenticatorTest.php
+++ b/Tests/Security/Guard/JwtAuthenticatorTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Security\Guard;
+
+use Auth0\JWTAuthBundle\Security\Auth0Service;
+use Auth0\JWTAuthBundle\Security\Guard\JwtAuthenticator;
+use Auth0\SDK\Exception\CoreException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+class JwtAuthenticatorTest extends TestCase
+{
+    /** @var JwtAuthenticator */
+    private $authenticator;
+
+    /** @var Auth0Service|MockObject */
+    private $auth0Service;
+
+    protected function setUp(): void
+    {
+        $this->auth0Service = $this->getMockBuilder(Auth0Service::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->authenticator = new JwtAuthenticator($this->auth0Service);
+    }
+
+    public function testJwtAuthenticatorDontSupportWithoutAuthorizationHeader()
+    {
+        $request = Request::create('/');
+        $this->assertFalse($this->authenticator->supports($request));
+    }
+
+    public function testAuthenticateMethodFailIfNoAuthorizationHeaderInRequest()
+    {
+        $request = Request::create('/');
+        $this->expectExceptionMessage('JWT is missing in the request Authorization header');
+
+        $this->authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateFailsIfAuthorizationHeaderIsNotABearer()
+    {
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'someInvalidStuff');
+        $this->expectExceptionMessage('JWT is not a bearer token');
+
+        $this->authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateFailsIfJwtDecodeFails()
+    {
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer invalidToken');
+
+        $this->auth0Service->expects($this->once())
+            ->method('decodeJWT')
+            ->with('invalidToken')
+            ->willThrowException(new CoreException('invalid token'))
+        ;
+
+        $this->expectException(AuthenticationException::class);
+
+        $this->authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateFailsIfDecodedJwtIsEmpty()
+    {
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+
+        $this->auth0Service->expects($this->once())
+            ->method('decodeJWT')
+            ->with('token')
+            ->willReturn(null)
+        ;
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Your JWT seems invalid');
+
+        $this->authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateCanSuccess()
+    {
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer amazingToken');
+
+        $jwt = new \stdClass();
+        $jwt->sub = 'authenticated-user';
+        $jwt->token = 'amazingToken';
+        $this->auth0Service->expects($this->once())
+            ->method('decodeJWT')
+            ->with('amazingToken')
+            ->willReturn($jwt)
+        ;
+
+        $passport = $this->authenticator->authenticate($request);
+        $this->assertInstanceOf(SelfValidatingPassport::class, $passport);
+
+
+        $fakeUser = new class implements UserInterface {
+            public function getRoles(){}
+            public function getPassword(){}
+            public function getSalt(){}
+            public function eraseCredentials(){}
+            public function getUsername(){}
+        };
+
+        $userProviderHasBeenCalled = false;
+        $userProvider = function($jwtString) use($fakeUser, &$userProviderHasBeenCalled) {
+            $this->assertSame('amazingToken', $jwtString);
+            $userProviderHasBeenCalled = true;
+            return $fakeUser;
+        };
+        $userBadge = $passport->getBadge(UserBadge::class);
+        // Registering the user provider on the user badge is done by a symfony listener.
+        $userBadge->setUserLoader($userProvider);
+
+        $this->assertSame($fakeUser, $passport->getUser());
+        $this->assertTrue($userProviderHasBeenCalled);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   "require-dev": {
     "phpunit/phpunit": "^9.3",
     "nyholm/symfony-bundle-test": "^1.0.2",
-    "symfony/security": "^4.4 || ~5.1",
+    "symfony/security-http": "^4.4 || ^5.1",
     "squizlabs/php_codesniffer": "^3.2",
     "phpcompatibility/php-compatibility": "^8.1",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   "require-dev": {
     "phpunit/phpunit": "^9.3",
     "nyholm/symfony-bundle-test": "^1.0.2",
-    "symfony/security-http": "^4.4 || ^5.1",
+    "symfony/security-http": "^4.4 || ^5.1 || ^6.0",
     "squizlabs/php_codesniffer": "^3.2",
     "phpcompatibility/php-compatibility": "^8.1",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -16,12 +16,19 @@ services:
   Auth0\JWTAuthBundle\Security\Auth0Service:
     alias: jwt_auth.auth0_service
 
+  # Authenticators
   jwt_auth.jwt_authenticator:
     class: Auth0\JWTAuthBundle\Security\JWTAuthenticator
     arguments: ["@jwt_auth.auth0_service"]
 
   jwt_auth.security.guard.jwt_guard_authenticator:
     class: Auth0\JWTAuthBundle\Security\Guard\JwtGuardAuthenticator
+    arguments:
+      - "@jwt_auth.auth0_service"
+
+  # SF >=5.3
+  jwt_auth.security.guard.jwt_authenticator:
+    class: Auth0\JWTAuthBundle\Security\Guard\JwtAuthenticator
     arguments:
       - "@jwt_auth.auth0_service"
 

--- a/src/Security/Core/JWTInfoNotFoundException.php
+++ b/src/Security/Core/JWTInfoNotFoundException.php
@@ -5,18 +5,10 @@ namespace Auth0\JWTAuthBundle\Security\Core;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 /**
- * AuthenticationException extension for JWT token handling.
+ * AuthenticationException exception when JWT is missing.
  */
 class JWTInfoNotFoundException extends AuthenticationException
 {
-
-    /**
-     * Store for our JWT.
-     *
-     * @var string
-     */
-    private $jwt;
-
     /**
      * {@inheritdoc}
      *
@@ -25,64 +17,5 @@ class JWTInfoNotFoundException extends AuthenticationException
     public function getMessageKey(): string
     {
         return 'JWT could not be found.';
-    }
-
-    /**
-     * Get the user jwt.
-     *
-     * @return string
-     */
-    public function getJWT(): string
-    {
-        return $this->jwt;
-    }
-
-    /**
-     * Set the user jwt.
-     *
-     * @param string $jwt A valid JWT object.
-     *
-     * @return void
-     */
-    public function setJWT($jwt): void
-    {
-        $this->jwt = $jwt;
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return string The string representing the serialized JWT.
-     */
-    public function serialize(): string
-    {
-        return serialize([
-            $this->jwt,
-            parent::serialize(),
-        ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param string $str A string representing a serialized JWT.
-     *
-     * @return void
-     */
-    public function unserialize($str)
-    {
-        list($this->jwt, $parentData) = unserialize($str);
-
-        parent::unserialize($parentData);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return array<string,mixed>
-     */
-    public function getMessageData(): array
-    {
-        return ['{{ jwt }}' => $this->jwt];
     }
 }

--- a/src/Security/Guard/AuthenticatorTrait.php
+++ b/src/Security/Guard/AuthenticatorTrait.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Auth0\JWTAuthBundle\Security\Guard;
+
+
+trait AuthenticatorTrait
+{
+
+}

--- a/src/Security/Guard/AuthenticatorTrait.php
+++ b/src/Security/Guard/AuthenticatorTrait.php
@@ -4,7 +4,35 @@ declare(strict_types=1);
 namespace Auth0\JWTAuthBundle\Security\Guard;
 
 
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
 trait AuthenticatorTrait
 {
+    public function supports(Request $request): ?bool
+    {
+        return $request->headers->has('Authorization') &&
+            strpos($request->headers->get('Authorization'), 'Bearer') === 0;
+    }
 
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        // Let the request continue, we don't want to redirect the user to some login page.
+        return null;
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        $responseBody = [
+            'message' => sprintf(
+                'Authentication failed: %s.',
+                rtrim($exception->getMessage(), '.')
+            ),
+        ];
+
+        return new JsonResponse($responseBody, JsonResponse::HTTP_UNAUTHORIZED);
+    }
 }

--- a/src/Security/Guard/JwtAuthenticator.php
+++ b/src/Security/Guard/JwtAuthenticator.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace Auth0\JWTAuthBundle\Security\Guard;
+
+use Auth0\JWTAuthBundle\Security\Auth0Service;
+use Auth0\JWTAuthBundle\Security\Core\JWTInfoNotFoundException;
+use Auth0\SDK\Exception\CoreException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+class JwtAuthenticator extends AbstractAuthenticator
+{
+    use AuthenticatorTrait;
+
+    /**
+     * Reference to an instance of Auth0Service.
+     *
+     * @var Auth0Service
+     */
+    private $auth0Service;
+
+    public function __construct(Auth0Service $auth0Service)
+    {
+        $this->auth0Service = $auth0Service;
+    }
+
+    public function authenticate(Request $request): PassportInterface
+    {
+        $jwtString = $request->headers->get('Authorization');
+        if (!$jwtString) {
+            throw new JWTInfoNotFoundException('JWT is missing in the request Authorization header');
+        }
+
+        if (0 !== strpos(strtolower($jwtString), 'bearer ')) {
+            throw new JWTInfoNotFoundException('JWT is not a bearer token');
+        }
+
+        try {
+            $jwtString = str_replace(['Bearer ', 'bearer '], ['',  ''], $jwtString);
+            $jwt = $this->auth0Service->decodeJWT($jwtString);
+        } catch (CoreException $exception) {
+            throw new AuthenticationException($exception->getMessage(), $exception->getCode(), $exception);
+        }
+
+        if (!$jwt) {
+            throw new AuthenticationException('Your JWT seems invalid');
+        }
+
+        return new SelfValidatingPassport(new UserBadge($jwtString));
+    }
+}


### PR DESCRIPTION
### Changes

This PR add a new authenticator following[ Symfony > 5.1 guidelines](https://symfony.com/doc/current/security/custom_authenticator.html#security-passports). 
It shouldn't impact the current usage of this library because it requires a specific configuration to use it (see update in readme)

### References
This issue is reported [here](https://github.com/auth0/jwt-auth-bundle/issues/115)

### Testing

Use Symfony >5.1 and follow the `config/security.yaml` example in readme file.

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of Symfony

## This PR is in WIP because some points need to be discussed 

1. The data given to the user provider is **no more** a jwt object, it's the JWT string. It's due to the new Symfony mechanism that [allows only a string](https://github.com/symfony/security-http/blob/5.3/Authenticator/Passport/Badge/UserBadge.php#L46). I'm pretty sure it's not possible to work with something else than a string. I spend 1 hour trying to hack this system ^^ 
But I think it's ok that your library API change (jwt object -> string jwt), because it will require a manual change in the configuration to activate this new authenticator. Being explicit in the upgrade.md should be enough 

2. I broke the old tests, but I can't figure out what's the problem. Maybe you could help me @evansims ^^' ? 
 
