### PR TITLE
Remove dead link to quickstart documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,6 @@ jwt_auth:
     leeway: 60
 ```
 
-## Demo
-
-[Symfony API Samples](https://github.com/auth0-community/auth0-symfony-api-samples)
-
 ## Auth0 integration
 
 The [Auth0 PHP SDK](https://github.com/auth0/auth0-PHP) is included in this bundle to handle the processing of JWTs. You can inject to your `UserProvider` to get the user profile, [example code](https://github.com/auth0-community/auth0-symfony-api-samples/blob/master/01-Authorization-RS256/src/AppBundle/Security/A0UserProvider.php).


### PR DESCRIPTION
This PR removes the quickstart link, as it has been archived as obsolete for some time.