### PR TITLE
Fix test suite: resolve "phpcodesniffer-composer-installer" warning during `composer compat`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,5 +60,12 @@
     "psr-4": {
       "Auth0\\JWTAuthBundle\\": "Tests/"
     }
+  },
+  "config": {
+    "optimize-autoloader": true,
+    "sort-packages": true,
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,8 @@
     "optimize-autoloader": true,
     "sort-packages": true,
     "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "phpstan/extension-installer": true
     }
   }
 }


### PR DESCRIPTION
This PR resolves the following error, raised when `composer compat` is run during CircleCI test tooling.

```sh
dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "dealerdirect/phpcodesniffer-composer-installer" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] 
                                                          
  [Symfony\Component\Console\Exception\RuntimeException]  
  Aborted                                                 
                                                          
```