### PR TITLE
feat: Add Symfony Cache component support

### DIFF
--- a/src/Auth0Bundle.php
+++ b/src/Auth0Bundle.php
@@ -26,19 +26,14 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
 
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
-        $tokenCache = $config['sdk']['token_cache'] ?? null;
-        $managementTokenCache = $config['sdk']['management_token_cache'] ?? null;
+        $tokenCache = $config['sdk']['token_cache'] ?? '';
+        $managementTokenCache = $config['sdk']['management_token_cache'] ?? '';
         $transientStorage = $config['sdk']['transient_storage'] ?? null;
         $sessionStorage = $config['sdk']['session_storage'] ?? null;
         $eventListenerProvider = $config['sdk']['event_listener_provider'] ?? null;
 
-        if (null !== $tokenCache && '' !== $tokenCache) {
-            $tokenCache = new Reference($tokenCache);
-        }
-
-        if (null !== $managementTokenCache && '' !== $managementTokenCache) {
-            $managementTokenCache = new Reference($managementTokenCache);
-        }
+        $tokenCache = new Reference('' === $tokenCache ? 'cache.app' : $tokenCache);
+        $managementTokenCache = new Reference('' === $managementTokenCache ? 'cache.app' : $managementTokenCache);
 
         if (null !== $transientStorage && '' !== $transientStorage) {
             $transientStorage = new Reference($transientStorage);
@@ -87,7 +82,7 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
                 ->arg('$tokenJwksUri', $config['sdk']['token_jwks_uri'])
                 ->arg('$tokenMaxAge', $config['sdk']['token_max_age'])
                 ->arg('$tokenLeeway', $config['sdk']['token_leeway'] ?? 60)
-                ->arg('$tokenCache', $tokenCache)
+                ->arg('$tokenCache', null)
                 ->arg('$tokenCacheTtl', $config['sdk']['token_cache_ttl'])
                 ->arg('$httpClient', $config['sdk']['http_client'])
                 ->arg('$httpMaxRetries', $config['sdk']['http_max_retries'])
@@ -111,7 +106,7 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
                 ->arg('$transientStorageId', $config['sdk']['transient_storage_id'])
                 ->arg('$queryUserInfo', false)
                 ->arg('$managementToken', $config['sdk']['management_token'])
-                ->arg('$managementTokenCache', $managementTokenCache)
+                ->arg('$managementTokenCache', null)
                 ->arg('$eventListenerProvider', $eventListenerProvider)
         ;
 
@@ -119,6 +114,8 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
             ->set('auth0', Service::class)
                 ->arg('$configuration', new Reference('auth0.configuration'))
                 ->arg('$logger', new Reference('logger'))
+                ->arg('$tokenCache', $tokenCache)
+                ->arg('$managementTokenCache', $managementTokenCache)
         ;
 
         $container->services()

--- a/src/Service.php
+++ b/src/Service.php
@@ -11,6 +11,7 @@ use Auth0\SDK\Store\CookieStore;
 use Auth0\Symfony\Contracts\ServiceInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Contracts\Cache\CacheInterface;
 
 final class Service implements ServiceInterface
 {
@@ -18,9 +19,18 @@ final class Service implements ServiceInterface
 
     public function __construct(
         private SdkConfiguration $configuration,
-        private LoggerInterface $logger
+        private LoggerInterface $logger,
+        private ?CacheItemPoolInterface $tokenCache,
+        private ?CacheItemPoolInterface $managementTokenCache,
     )
     {
+        if (null !== $tokenCache) {
+            $configuration->setTokenCache($tokenCache);
+        }
+
+        if (null !== $managementTokenCache) {
+            $configuration->setManagementTokenCache($managementTokenCache);
+        }
     }
 
     public function getSdk()


### PR DESCRIPTION
This PR adds Symfony Cache component support to the SDK. The SDK will invoke the PSR-6-based interface, and connect it directly to the CacheItemPoolInterface property of the Auth0-PHP SDK. This caching feature will be used for JWKS caching to reduce network requests, and caching of Management API tokens generated through the API.

By default, it will use the basic `cache.app` pool, which uses the filesystem adapter. Developers can add new cache pools and define adapters in their `config/package/cache.yaml` file to customize the behavior.
