### PR TITLE
feat: Add Symfony Session storage support

### DIFF
--- a/src/Auth0Bundle.php
+++ b/src/Auth0Bundle.php
@@ -26,19 +26,14 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
 
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
-        $tokenCache = $config['sdk']['token_cache'] ?? null;
-        $managementTokenCache = $config['sdk']['management_token_cache'] ?? null;
+        $tokenCache = $config['sdk']['token_cache'] ?? '';
+        $managementTokenCache = $config['sdk']['management_token_cache'] ?? '';
         $transientStorage = $config['sdk']['transient_storage'] ?? null;
         $sessionStorage = $config['sdk']['session_storage'] ?? null;
         $eventListenerProvider = $config['sdk']['event_listener_provider'] ?? null;
 
-        if (null !== $tokenCache && '' !== $tokenCache) {
-            $tokenCache = new Reference($tokenCache);
-        }
-
-        if (null !== $managementTokenCache && '' !== $managementTokenCache) {
-            $managementTokenCache = new Reference($managementTokenCache);
-        }
+        $tokenCache = new Reference('' === $tokenCache ? 'cache.app' : $tokenCache);
+        $managementTokenCache = new Reference('' === $managementTokenCache ? 'cache.app' : $managementTokenCache);
 
         if (null !== $transientStorage && '' !== $transientStorage) {
             $transientStorage = new Reference($transientStorage);
@@ -87,7 +82,7 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
                 ->arg('$tokenJwksUri', $config['sdk']['token_jwks_uri'])
                 ->arg('$tokenMaxAge', $config['sdk']['token_max_age'])
                 ->arg('$tokenLeeway', $config['sdk']['token_leeway'] ?? 60)
-                ->arg('$tokenCache', $tokenCache)
+                ->arg('$tokenCache', null)
                 ->arg('$tokenCacheTtl', $config['sdk']['token_cache_ttl'])
                 ->arg('$httpClient', $config['sdk']['http_client'])
                 ->arg('$httpMaxRetries', $config['sdk']['http_max_retries'])
@@ -111,7 +106,7 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
                 ->arg('$transientStorageId', $config['sdk']['transient_storage_id'])
                 ->arg('$queryUserInfo', false)
                 ->arg('$managementToken', $config['sdk']['management_token'])
-                ->arg('$managementTokenCache', $managementTokenCache)
+                ->arg('$managementTokenCache', null)
                 ->arg('$eventListenerProvider', $eventListenerProvider)
         ;
 
@@ -119,6 +114,8 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
             ->set('auth0', Service::class)
                 ->arg('$configuration', new Reference('auth0.configuration'))
                 ->arg('$logger', new Reference('logger'))
+                ->arg('$tokenCache', $tokenCache)
+                ->arg('$managementTokenCache', $managementTokenCache)
         ;
 
         $container->services()

--- a/src/Auth0Bundle.php
+++ b/src/Auth0Bundle.php
@@ -16,9 +16,7 @@ use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
-use Symfony\Component\HttpKernel\KernelEvents;
 
 final class Auth0Bundle extends AbstractBundle implements BundleInterface
 {

--- a/src/Auth0Bundle.php
+++ b/src/Auth0Bundle.php
@@ -11,11 +11,14 @@ use Auth0\Symfony\Controllers\AuthenticationController;
 use Auth0\Symfony\Security\Authenticator;
 use Auth0\Symfony\Security\Authorizer;
 use Auth0\Symfony\Security\UserProvider;
+use Auth0\Symfony\Stores\SessionStore;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+use Symfony\Component\HttpKernel\KernelEvents;
 
 final class Auth0Bundle extends AbstractBundle implements BundleInterface
 {
@@ -26,22 +29,19 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
 
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
-        $tokenCache = $config['sdk']['token_cache'] ?? '';
-        $managementTokenCache = $config['sdk']['management_token_cache'] ?? '';
-        $transientStorage = $config['sdk']['transient_storage'] ?? null;
-        $sessionStorage = $config['sdk']['session_storage'] ?? null;
+        $tokenCache = $config['sdk']['token_cache'] ?? 'cache.app';
+        $tokenCache = new Reference($tokenCache);
+
+        $managementTokenCache = $config['sdk']['management_token_cache'] ?? 'cache.app';
+        $managementTokenCache = new Reference($managementTokenCache);
+
+        $transientStorage = new Reference($config['sdk']['transient_storage'] ?? 'auth0.store_transient');
+        $sessionStorage = new Reference($config['sdk']['session_storage'] ?? 'auth0.store_session');
+
+        $transientStoragePrefix = $config['sdk']['transient_storage_prefix'] ?? 'auth0_transient';
+        $sessionStoragePrefix = $config['sdk']['session_storage_prefix'] ?? 'auth0_session';
+
         $eventListenerProvider = $config['sdk']['event_listener_provider'] ?? null;
-
-        $tokenCache = new Reference('' === $tokenCache ? 'cache.app' : $tokenCache);
-        $managementTokenCache = new Reference('' === $managementTokenCache ? 'cache.app' : $managementTokenCache);
-
-        if (null !== $transientStorage && '' !== $transientStorage) {
-            $transientStorage = new Reference($transientStorage);
-        }
-
-        if (null !== $sessionStorage && '' !== $sessionStorage) {
-            $sessionStorage = new Reference($sessionStorage);
-        }
 
         if (null !== $eventListenerProvider && '' !== $eventListenerProvider) {
             $eventListenerProvider = new Reference($eventListenerProvider);
@@ -82,7 +82,7 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
                 ->arg('$tokenJwksUri', $config['sdk']['token_jwks_uri'])
                 ->arg('$tokenMaxAge', $config['sdk']['token_max_age'])
                 ->arg('$tokenLeeway', $config['sdk']['token_leeway'] ?? 60)
-                ->arg('$tokenCache', null)
+                ->arg('$tokenCache', $tokenCache)
                 ->arg('$tokenCacheTtl', $config['sdk']['token_cache_ttl'])
                 ->arg('$httpClient', $config['sdk']['http_client'])
                 ->arg('$httpMaxRetries', $config['sdk']['http_max_retries'])
@@ -91,7 +91,7 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
                 ->arg('$httpStreamFactory', $config['sdk']['http_stream_factory'])
                 ->arg('$httpTelemetry', $config['sdk']['http_telemetry'])
                 ->arg('$sessionStorage', $sessionStorage)
-                ->arg('$sessionStorageId', $config['sdk']['session_storage_id'])
+                ->arg('$sessionStorageId', $sessionStoragePrefix)
                 ->arg('$cookieSecret', $config['sdk']['cookie_secret'])
                 ->arg('$cookieDomain', $config['sdk']['cookie_domain'])
                 ->arg('$cookieExpires', $config['sdk']['cookie_expires'])
@@ -103,19 +103,19 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
                 ->arg('$persistAccessToken', true)
                 ->arg('$persistRefreshToken', true)
                 ->arg('$transientStorage', $transientStorage)
-                ->arg('$transientStorageId', $config['sdk']['transient_storage_id'])
+                ->arg('$transientStorageId', $transientStoragePrefix)
                 ->arg('$queryUserInfo', false)
                 ->arg('$managementToken', $config['sdk']['management_token'])
-                ->arg('$managementTokenCache', null)
+                ->arg('$managementTokenCache', $managementTokenCache)
                 ->arg('$eventListenerProvider', $eventListenerProvider)
         ;
 
         $container->services()
             ->set('auth0', Service::class)
                 ->arg('$configuration', new Reference('auth0.configuration'))
+                ->arg('$requestStack', new Reference('request_stack'))
                 ->arg('$logger', new Reference('logger'))
-                ->arg('$tokenCache', $tokenCache)
-                ->arg('$managementTokenCache', $managementTokenCache)
+                ->tag('routing.condition_service')
         ;
 
         $container->services()
@@ -124,11 +124,26 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
                 ->arg('$service', new Reference('auth0'))
                 ->arg('$router', new Reference('router'))
                 ->arg('$logger', new Reference('logger'))
+                ->tag('security.authenticator')
+        ;
+
+        $container->services()
+            ->set('auth0.store_session', SessionStore::class)
+                ->arg('$namespace', $sessionStoragePrefix)
+                ->arg('$requestStack', new Reference('request_stack'))
+                ->arg('$logger', new Reference('logger'))
+        ;
+
+        $container->services()
+            ->set('auth0.store_transient', SessionStore::class)
+                ->arg('$namespace', $transientStoragePrefix)
+                ->arg('$requestStack', new Reference('request_stack'))
+                ->arg('$logger', new Reference('logger'))
         ;
 
         $container->services()
             ->set('auth0.authorizer', Authorizer::class)
-            ->arg('$configuration', $config['authorizer'] ?? [])
+                ->arg('$configuration', $config['authorizer'] ?? [])
                 ->arg('$service', new Reference('auth0'))
                 ->arg('$logger', new Reference('logger'))
         ;

--- a/src/Security/Authenticator.php
+++ b/src/Security/Authenticator.php
@@ -22,22 +22,12 @@ use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPasspor
 final class Authenticator extends AbstractAuthenticator implements AuthenticatorInterface
 {
     public function __construct(
-        private array $configuration,
-        private Service $service,
+        public array $configuration,
+        public Service $service,
         private RouterInterface $router,
         private LoggerInterface $logger
     )
     {
-    }
-
-    public function getService(): Service
-    {
-        return $this->service;
-    }
-
-    public function getConfiguration(): array
-    {
-        return $this->configuration;
     }
 
     public function supports(Request $request): ?bool

--- a/src/Service.php
+++ b/src/Service.php
@@ -11,6 +11,7 @@ use Auth0\SDK\Store\CookieStore;
 use Auth0\Symfony\Contracts\ServiceInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Contracts\Cache\CacheInterface;
 
 final class Service implements ServiceInterface
 {
@@ -18,9 +19,18 @@ final class Service implements ServiceInterface
 
     public function __construct(
         private SdkConfiguration $configuration,
-        private LoggerInterface $logger
+        private LoggerInterface $logger,
+        private ?CacheItemPoolInterface $tokenCache,
+        private ?CacheItemPoolInterface $managementTokenCache,
     )
     {
+        if (null !== $tokenCache) {
+            $configuration->setTokenCache($tokenCache);
+        }
+
+        if (null !== $managementTokenCache) {
+            $configuration->setManagementTokenCache($managementTokenCache);
+        }
     }
 
     public function getSdk()

--- a/src/Stores/SessionStore.php
+++ b/src/Stores/SessionStore.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Symfony\Stores;
+
+use Auth0\SDK\Contract\StoreInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Throwable;
+
+final class SessionStore implements StoreInterface
+{
+    public function __construct(
+        private $namespace,
+        private RequestStack $requestStack,
+        private LoggerInterface $logger
+    ) {
+    }
+
+    /**
+     * This has no effect when using sessions as the storage medium.
+     *
+     * @param  bool  $deferring  whether to defer persisting the storage state
+     *
+     * @codeCoverageIgnore
+     */
+    public function defer(
+        bool $deferring,
+    ): void {
+    }
+
+    /**
+     * Persists $value on $_SESSION, identified by $key.
+     *
+     * @param  string  $key  session key to set
+     * @param  mixed  $value  value to use
+     */
+    public function set(
+        string $key,
+        $value,
+    ): void {
+        $manifest = $this->session()?->get($this->namespace, []);
+
+        $manifest[$key] = $value;
+
+        $this->session()?->set($this->namespace, $manifest);
+    }
+
+    /**
+     * Gets persisted values identified by $key.
+     * If the value is not set, returns $default.
+     *
+     * @param  string  $key  session key to set
+     * @param  mixed  $default  default to return if nothing was found
+     * @return mixed
+     */
+    public function get(
+        string $key,
+        $default = null,
+    ) {
+        $manifest = $this->session()?->get($this->namespace, []);
+
+        if ([] === $manifest || ! isset($manifest[$key])) {
+          return $default;
+        }
+
+        return $manifest[$key];
+    }
+
+    /**
+     * Removes all persisted values.
+     */
+    public function purge(): void
+    {
+        $this->session()?->remove($this->namespace);
+    }
+
+    /**
+     * Removes a persisted value identified by $key.
+     *
+     * @param  string  $key  session key to delete
+     */
+    public function delete(
+        string $key,
+    ): void {
+        $manifest = $this->session()?->get($this->namespace, []);
+
+        if ([] === $manifest) {
+            return;
+        }
+
+        if (isset($manifest[$key])) {
+            unset($manifest[$key]);
+
+            if ([] === $manifest) {
+                $this->session()?->remove($this->namespace);
+                return;
+            }
+
+            $this->session()?->set($this->namespace, $manifest);
+        }
+    }
+
+    private function session(
+      ?Request $request = null
+    ): ?SessionInterface {
+        if (session_status() === PHP_SESSION_DISABLED) {
+            return null;
+        }
+
+        $request ??= $this->requestStack->getCurrentRequest();
+        $session = null;
+
+        try {
+            $session = $request->getSession();
+        } catch (Throwable) {
+        }
+
+        if ($session) {
+            if (null !== $session && ! $session->isStarted()) {
+                $session->start();
+            }
+
+            return $session;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
This PR adds Symfony Session storage support to the SDK. At runtime, the SDK will initialize a new StoreInterface bridge-class that allows the underlying Auth0-PHP SDK to store session state using Symfony's session management APIs.

This enables developers to use all the existing Symfony session APIs they're probably already integrated with to engage with authenticated user identities throughout their applications. It also enables developers choice in where session data is stored, including within databases or memory stores like Redis.