### PR TITLE
dependencies : allow symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,9 @@
     "ext-mbstring": "*",
     "ext-openssl": "*",
     "auth0/auth0-php": "^8.18",
-    "symfony/cache": "^6.4 || ^7.0",
-    "symfony/framework-bundle": "^6.4 || ^7.0",
-    "symfony/security-bundle": "^6.4 || ^7.0"
+    "symfony/cache": "^6.4 || ^7.0 || ^8.0",
+    "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
+    "symfony/security-bundle": "^6.4 || ^7.0 || ^8.0"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2",


### PR DESCRIPTION
### Changes

~~Symfony 8 is soon to be released (https://symfony.com/releases/8.0)
8.0.0 RC3 was released 5 days ago.~~

Symfony 8 is released (https://symfony.com/releases/8.0)

I've added ^8.0 as an allowed version for symfony dependencies on this project.

### References

- https://symfony.com/releases/8.0

### Testing

This change is there to be able to test on the latest version of Symfony

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
