### PR TITLE
Fix deprecated Request::get() methods and Psalm issues

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -8,6 +8,11 @@
     findUnusedBaselineEntry="true"
     findUnusedCode="false"
 >
+    <!-- <php>
+        <ini name="max_execution_time" value="120"/>
+        <ini name="memory_limit" value="512M"/>
+    </php> -->
+
     <projectFiles>
         <directory name="src" />
     </projectFiles>

--- a/src/Controllers/AuthenticationController.php
+++ b/src/Controllers/AuthenticationController.php
@@ -36,8 +36,8 @@ final class AuthenticationController extends AbstractController implements Authe
         $session = $this->getSdk()->getCredentials();
 
         if (null === $session) {
-            $code = $request->get('code');
-            $state = $request->get('state');
+            $code = $request->query->get('code');
+            $state = $request->query->get('state');
 
             $code = is_string($code) ? trim($code) : '';
             $state = is_string($state) ? trim($state) : '';

--- a/src/Controllers/BackchannelLogoutController.php
+++ b/src/Controllers/BackchannelLogoutController.php
@@ -31,7 +31,7 @@ final class BackchannelLogoutController extends AbstractController implements Au
             return new Response('', Response::HTTP_METHOD_NOT_ALLOWED);
         }
 
-        $logoutToken = $request->get('logout_token');
+        $logoutToken = $request->request->get('logout_token');
 
         if (! is_string($logoutToken)) {
             return new Response('', Response::HTTP_BAD_REQUEST);

--- a/src/Security/Authorizer.php
+++ b/src/Security/Authorizer.php
@@ -38,12 +38,14 @@ final class Authorizer extends AbstractAuthenticator implements AuthorizerInterf
     public function authenticate(Request $request): Passport
     {
         // Extract any available value from the authorization header
-        $param = $request->get('token', null);
+        $param = $request->query->get('token');
         $header = trim($request->headers->get('Authorization', '') ?? '');
-        $token = $param ?? $header;
         $usingHeader = null === $param;
 
-        // Ensure the 'authorization' header is present in the request
+        /** @var mixed $token */
+        $token = $param ?? $header;
+
+        // Ensure the token is a valid string
         if (! is_string($token) || '' === $token) {
             throw new AuthenticationException('`Authorization` header not present.');
         }
@@ -107,7 +109,7 @@ final class Authorizer extends AbstractAuthenticator implements AuthorizerInterf
      */
     public function supports(Request $request): ?bool
     {
-        if (null !== $request->get('token')) {
+        if (null !== $request->query->get('token')) {
             return true;
         }
 


### PR DESCRIPTION
### Changes

- **Fixed deprecated `Request::get()` methods** to use explicit parameter bag methods for Symfony compatibility

- **Resolved Psalm type inference error** annotation to clarify mixed type handling from query parameters
