### PR TITLE
chore(security): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       # Checkout the code
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/rl-scanner.yml
+++ b/.github/workflows/rl-scanner.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha || github.ref }}
 

--- a/.github/workflows/rl-scanner.yml
+++ b/.github/workflows/rl-scanner.yml
@@ -37,7 +37,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha || github.ref }}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # pin@2.32.0
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # pin@2.37.2
         with:
           php-version: ${{ inputs.php-version }}
 

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -34,7 +34,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || github.ref }}
 
@@ -51,7 +51,7 @@ jobs:
       - if: github.actor == 'dependabot[bot]' || github.event_name == 'merge_group'
         run: exit 0
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || github.ref }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha || github.ref }}
 
@@ -42,7 +42,7 @@ jobs:
       matrix: ${{ fromJson(needs.configure.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha || github.ref }}
 
@@ -60,7 +60,7 @@ jobs:
       matrix: ${{ fromJson(needs.configure.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha || github.ref }}
 
@@ -88,7 +88,7 @@ jobs:
       matrix: ${{ fromJson(needs.configure.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha || github.ref }}
 
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha || github.ref }}
 
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha || github.ref }}
 
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha || github.ref }}
 
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha || github.ref }}
 
@@ -168,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha || github.ref }}
 

--- a/.snyk
+++ b/.snyk
@@ -1,7 +1,9 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.5.0
+version: v1.12.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  snyk:lic:composer:auth0:auth0-php:Unknown:
+  "snyk:lic:composer:auth0:auth0-php:Unknown":
     - '*':
-        reason: auth0/auth0-php is MIT-licensed; Snyk lacks license metadata for 8.19.0
-        expires: 2027-06-10T00:00:00.000Z
+        reason: "auth0/auth0-php is MIT-licensed; Snyk lacks license metadata for 8.19.0"
+        expires: "2027-06-10T00:00:00.000Z"
+patch: {}

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,7 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.5.0
+ignore:
+  snyk:lic:composer:auth0:auth0-php:Unknown:
+    - '*':
+        reason: auth0/auth0-php is MIT-licensed; Snyk lacks license metadata for 8.19.0
+        expires: 2027-06-10T00:00:00.000Z

--- a/src/Auth0Bundle.php
+++ b/src/Auth0Bundle.php
@@ -29,11 +29,11 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
     }
 
     /**
-     * @param array<mixed>          $config    The configuration array.
-     * @param ContainerConfigurator $container The container configurator.
-     * @param ContainerBuilder      $builder   The container builder.
+     * @param array<mixed>          $config       The configuration array.
+     * @param ContainerConfigurator $configurator The container configurator.
+     * @param ContainerBuilder      $container    The container builder.
      */
-    public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
+    public function loadExtension(array $config, ContainerConfigurator $configurator, ContainerBuilder $container): void
     {
         $sdkConfig = $config['sdk'] ?? [];
 
@@ -119,7 +119,7 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
             $scopes = null;
         }
 
-        $container->services()
+        $configurator->services()
             ->set('auth0.configuration', SdkConfiguration::class)
             ->arg('$configuration', null)
             ->arg('$strategy', $sdkConfig['strategy'])
@@ -167,14 +167,14 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
             ->arg('$backchannelLogoutCache', $backchannelLogoutCache)
             ->arg('$backchannelLogoutExpires', $sdkConfig['backchannel_logout_expires']);
 
-        $container->services()
+        $configurator->services()
             ->set('auth0', Service::class)
             ->arg('$configuration', new Reference('auth0.configuration'))
             ->arg('$requestStack', new Reference('request_stack'))
             ->arg('$logger', new Reference('logger'))
             ->tag('routing.condition_service');
 
-        $container->services()
+        $configurator->services()
             ->set('auth0.authenticator', Authenticator::class)
             ->arg('$configuration', $config['authenticator'] ?? [])
             ->arg('$service', new Reference('auth0'))
@@ -182,32 +182,32 @@ final class Auth0Bundle extends AbstractBundle implements BundleInterface
             ->arg('$logger', new Reference('logger'))
             ->tag('security.authenticator');
 
-        $container->services()
+        $configurator->services()
             ->set('auth0.store_session', SessionStore::class)
             ->arg('$namespace', $sessionStoragePrefix)
             ->arg('$requestStack', new Reference('request_stack'))
             ->arg('$logger', new Reference('logger'));
 
-        $container->services()
+        $configurator->services()
             ->set('auth0.store_transient', SessionStore::class)
             ->arg('$namespace', $transientStoragePrefix)
             ->arg('$requestStack', new Reference('request_stack'))
             ->arg('$logger', new Reference('logger'));
 
-        $container->services()
+        $configurator->services()
             ->set('auth0.authorizer', Authorizer::class)
             ->arg('$configuration', $config['authorizer'] ?? [])
             ->arg('$service', new Reference('auth0'))
             ->arg('$logger', new Reference('logger'));
 
-        $container->services()
+        $configurator->services()
             ->set(AuthenticationController::class)
             ->arg('$authenticator', new Reference('auth0.authenticator'))
             ->arg('$router', new Reference('router'))
             ->call('setContainer', [new Reference('service_container')])
             ->tag('controller.service_arguments');
 
-        $container->services()
+        $configurator->services()
             ->set(UserProvider::class)
             ->arg('$service', new Reference('auth0'));
     }

--- a/src/Stores/SessionStore.php
+++ b/src/Stores/SessionStore.php
@@ -58,7 +58,8 @@ final class SessionStore implements StoreInterface
     public function delete(
         string $key,
     ): void {
-        $manifest = $this->session()?->get($this->namespace, []);
+        $session = $this->session();
+        $manifest = $session?->get($this->namespace, []);
 
         if (! is_array($manifest) || [] === $manifest) {
             return;
@@ -68,12 +69,12 @@ final class SessionStore implements StoreInterface
             unset($manifest[$key]);
 
             if ([] === $manifest) {
-                $this->session()?->remove($this->namespace);
+                $session->remove($this->namespace);
 
                 return;
             }
 
-            $this->session()?->set($this->namespace, $manifest);
+            $session->set($this->namespace, $manifest);
         }
     }
 


### PR DESCRIPTION
## Changes

- Pin all third-party GitHub Actions to full-length commit SHAs (with version comments) across the `release`, `rl-scanner`, `snyk`, and `tests` workflows, improving security and reproducibility
- Bump `shivammathur/setup-php` from 2.32.0 to 2.37.2
- Fix `SessionStore::delete()` to capture the session once, removing redundant nullsafe operators flagged by PHPStan (`nullsafe.neverNull`)
- Align `Auth0Bundle::loadExtension()` parameter names with the parent `AbstractBundle`/`ConfigurableExtensionInterface` signature, resolving a Psalm `ParamNameMismatch`
- Add a `.snyk` policy to ignore the false-positive "Unknown license" flag for `auth0/auth0-php` (the package is MIT-licensed)

Based on [#238](https://github.com/auth0/symfony/pull/238) by ([jcchavezs](https://github.com/jcchavezs)), and includes the `shivammathur/setup-php` bump from [#237](https://github.com/auth0/symfony/pull/237).