### PR TITLE
[codex] Add named arguments Rector rule

### DIFF
--- a/src/Controllers/AuthenticationController.php
+++ b/src/Controllers/AuthenticationController.php
@@ -36,26 +36,26 @@ final class AuthenticationController extends AbstractController implements Authe
         $session = $this->getSdk()->getCredentials();
 
         if (null === $session) {
-            $code = $request->query->get('code');
-            $state = $request->query->get('state');
+            $code = $request->query->get(key: 'code');
+            $state = $request->query->get(key: 'state');
 
             $code = is_string($code) ? trim($code) : '';
             $state = is_string($state) ? trim($state) : '';
 
             if ('' !== $code && '' !== $state) {
-                $route = $this->getRedirectUrl('success');
+                $route = $this->getRedirectUrl(route: 'success');
 
                 try {
-                    $this->getSdk()->exchange($host . $route, $code, $state);
+                    $this->getSdk()->exchange(redirectUri: $host . $route, code: $code, state: $state);
 
                     if ($request->hasSession()) {
                         $redirect = $request->getSession()->get('auth0:callback_redirect', $redirect);
                         $request->getSession()->remove('auth0:callback_redirect');
                     }
                 } catch (Throwable $th) {
-                    $this->addFlash('error', $th->getMessage());
+                    $this->addFlash(type: 'error', message: $th->getMessage());
 
-                    $route = $this->getRedirectUrl('failure');
+                    $route = $this->getRedirectUrl(route: 'failure');
                     $redirect = $host . $route;
                 }
             }
@@ -65,7 +65,7 @@ final class AuthenticationController extends AbstractController implements Authe
          * @var string $redirect
          */
 
-        return new RedirectResponse($redirect);
+        return new RedirectResponse(url: $redirect);
     }
 
     public function login(Request $request): Response
@@ -73,15 +73,15 @@ final class AuthenticationController extends AbstractController implements Authe
         $session = $this->getSdk()->getCredentials();
 
         $host = $request->getSchemeAndHttpHost();
-        $route = $this->getRedirectUrl('success');
+        $route = $this->getRedirectUrl(route: 'success');
         $url = $host . $route;
 
         if (null === $session) {
-            $route = $this->getRedirectUrl('callback');
-            $url = $this->getSdk()->login($host . $route);
+            $route = $this->getRedirectUrl(route: 'callback');
+            $url = $this->getSdk()->login(redirectUrl: $host . $route);
         }
 
-        return new RedirectResponse($url);
+        return new RedirectResponse(url: $url);
     }
 
     public function logout(Request $request): Response
@@ -89,14 +89,14 @@ final class AuthenticationController extends AbstractController implements Authe
         $session = $this->getSdk()->getCredentials();
 
         $host = $request->getSchemeAndHttpHost();
-        $route = $this->getRedirectUrl('logout');
+        $route = $this->getRedirectUrl(route: 'logout');
         $url = $host . $route;
 
         if (null !== $session) {
-            $url = $this->getSdk()->logout($url);
+            $url = $this->getSdk()->logout(returnUri: $url);
         }
 
-        return new RedirectResponse($url);
+        return new RedirectResponse(url: $url);
     }
 
     private function getRedirectUrl(string $route): string

--- a/src/Security/Authenticator.php
+++ b/src/Security/Authenticator.php
@@ -40,12 +40,12 @@ final class Authenticator extends AbstractAuthenticator implements Authenticator
         $session = $this->service->getSdk()->getCredentials();
 
         if (null === $session) {
-            throw new CustomUserMessageAuthenticationException('No Auth0 session was found.');
+            throw new CustomUserMessageAuthenticationException(message: 'No Auth0 session was found.');
         }
 
         $user = json_encode(['type' => 'stateful', 'data' => $session], JSON_THROW_ON_ERROR);
 
-        return new SelfValidatingPassport(new UserBadge($user));
+        return new SelfValidatingPassport(userBadge: new UserBadge(userIdentifier: $user));
     }
 
     public function onAuthenticationFailure(Request $request, SymfonyAuthenticationException $exception): ?Response
@@ -64,7 +64,7 @@ final class Authenticator extends AbstractAuthenticator implements Authenticator
 
         if (is_string($route) && '' !== $route) {
             try {
-                return new RedirectResponse($this->router->generate($route));
+                return new RedirectResponse(url: $this->router->generate($route));
             } catch (Throwable) {
             }
         }

--- a/src/Security/Authorizer.php
+++ b/src/Security/Authorizer.php
@@ -35,10 +35,10 @@ final class Authorizer extends AbstractAuthenticator implements AuthorizerInterf
      */
     public function authenticate(Request $request): Passport
     {
-        $header = trim($request->headers->get('Authorization', '') ?? '');
+        $header = trim($request->headers->get(key: 'Authorization', default: '') ?? '');
 
         if ('' === $header || 0 !== stripos($header, 'bearer ')) {
-            throw new AuthenticationException('`Authorization` header is missing or malformed.');
+            throw new AuthenticationException(message: '`Authorization` header is missing or malformed.');
         }
 
         $token = substr($header, 7);
@@ -50,7 +50,7 @@ final class Authorizer extends AbstractAuthenticator implements AuthorizerInterf
 
         $user = json_encode(['type' => 'stateless', 'data' => ['user' => $token->toArray()]], JSON_THROW_ON_ERROR);
 
-        return new SelfValidatingPassport(new UserBadge($user));
+        return new SelfValidatingPassport(userBadge: new UserBadge(userIdentifier: $user));
     }
 
     /**
@@ -78,7 +78,7 @@ final class Authorizer extends AbstractAuthenticator implements AuthorizerInterf
             ],
         ];
 
-        return new JsonResponse($response, JsonResponse::HTTP_UNAUTHORIZED);
+        return new JsonResponse(data: $response, status: JsonResponse::HTTP_UNAUTHORIZED);
     }
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
@@ -93,6 +93,6 @@ final class Authorizer extends AbstractAuthenticator implements AuthorizerInterf
      */
     public function supports(Request $request): ?bool
     {
-        return $request->headers->has('Authorization') && 0 === stripos((string) $request->headers->get('Authorization'), 'Bearer ');
+        return $request->headers->has(key: 'Authorization') && 0 === stripos((string) $request->headers->get(key: 'Authorization'), 'Bearer ');
     }
 }

--- a/src/Security/UserProvider.php
+++ b/src/Security/UserProvider.php
@@ -45,10 +45,10 @@ final class UserProvider implements SymfonyUserProviderInterface, UserProviderIn
         $user = $data['user'] ?? null;
 
         if ('stateful' === $type) {
-            return new StatefulUser($user);
+            return new StatefulUser(data: $user);
         }
 
-        return new StatelessUser($user);
+        return new StatelessUser(data: $user);
     }
 
     public function refreshUser(SymfonyUserInterface $user): SymfonyUserInterface

--- a/src/Service.php
+++ b/src/Service.php
@@ -29,10 +29,10 @@ final class Service implements ServiceInterface
     {
         if (! $this->sdk instanceof Auth0) {
             $this->warmUp();
-            $this->sdk = new Auth0($this->configuration);
+            $this->sdk = new Auth0(configuration: $this->configuration);
 
-            HttpTelemetry::setEnvProperty('Symfony', Kernel::VERSION);
-            HttpTelemetry::setPackage('symfony', self::VERSION);
+            HttpTelemetry::setEnvProperty(name: 'Symfony', version: Kernel::VERSION);
+            HttpTelemetry::setPackage(name: 'symfony', version: self::VERSION);
         }
 
         return $this->sdk;


### PR DESCRIPTION
## What changed

This PR integrates `savinmikhail/add_named_arguments_rector` into the repository's Rector configuration and applies it to the current `src` tree.

It adds the rule as a dev dependency, wires it into `rector.php` with a conservative skip list for noisier built-in functions, and commits the resulting call-site updates.

## Why

This repository already uses an extensive Rector setup and targets modern PHP.

Named arguments improve readability in a few places that are easy to misread during maintenance, especially service wiring, Symfony container definitions, controllers, and SDK integration points. They also make the intent of call sites more explicit for AI-assisted code navigation and editing.

## Scope

The rule is intentionally configured conservatively. The skip list avoids adding names to common built-ins where the result becomes noisier than the original call.

## Validation

Passing in this environment:
- `composer rector`
- `composer phpstan`
- `composer phpcs`
- `vendor/bin/pest --colors=always --strict-global-state --fail-on-risky --fail-on-warning --compact`

Environment-limited here:
- `composer test` stops because the configured Pest script requires a code coverage driver, which is not available in this environment
- `composer psalm` stops because the local PHP is `8.3.6`, while the installed Psalm package requires `>= 8.3.16`
